### PR TITLE
Add Flask web client for procedural RTS prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,25 @@ To get started with development, follow these steps:
 
 1. Clone the repository: `git clone https://github.com/your-username/RTS_game.git`
 2. Navigate to the project directory: `cd RTS_game`
-3. Install dependencies: `pip install pygame noise`
-4. Start the game: `python main.py`
+3. Install dependencies: `pip install -r requirements.txt`
+4. Start the web server: `python app.py`
+5. Open the game in your browser: `http://127.0.0.1:5000`
+
+The legacy Pygame prototype is still available through `python main.py`,
+but the recommended way to experience the project is via the new web
+client.
 
 ## Project Structure
 
 The project is organized as follows:
 
 - `__pycache__/`: Python cache files.
-- `game.py`: Handles game logic, rendering, and state updates.
-- `main.py`: The entry point of the game. Manages game initialization and the main game loop.
+- `game.py`: Handles game logic, rendering, and state updates for the legacy desktop prototype.
+- `app.py`: Flask application that serves the browser based prototype.
+- `main.py`: Legacy Pygame entry point kept for reference.
 - `map_generator.py`: Responsible for generating the game map and managing terrain.
+- `web_map_generator.py`: Headless map generator used by the web server.
+- `templates/` and `static/`: Assets powering the single page web client.
 - `network/`: Contains networking code with `client.py` and `server.py` for multiplayer functionality.
 - `README.md`: Project documentation.
 - `test_all.py`: Script for running all tests.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,57 @@
+"""Flask application that exposes the RTS prototype as a web app."""
+from __future__ import annotations
+
+from flask import Flask, jsonify, render_template, request
+
+from web_map_generator import WebMapGenerator
+
+
+app = Flask(__name__)
+
+# A single shared generator keeps memory usage low and allows players to
+# request new maps on demand via the ``/api/map`` endpoint.
+MAP_GENERATOR = WebMapGenerator()
+
+
+@app.get("/")
+def index():
+    """Serve the single page application."""
+
+    return render_template("index.html")
+
+
+@app.get("/api/map")
+def get_map():
+    """Return the current map state.
+
+    The endpoint accepts an optional ``seed`` query argument, allowing the
+    front-end to trigger deterministic world generation when desired.
+    """
+
+    seed_arg = request.args.get("seed")
+    if seed_arg is not None:
+        try:
+            MAP_GENERATOR.regenerate(seed=int(seed_arg))
+        except ValueError as exc:  # pragma: no cover - validation is minimal
+            return jsonify({"error": str(exc)}), 400
+    return jsonify(MAP_GENERATOR.serialise())
+
+
+@app.post("/api/map/regenerate")
+def regenerate_map():
+    """Trigger a brand new procedurally generated map."""
+
+    payload = request.get_json(silent=True) or {}
+    seed = payload.get("seed")
+    if seed is not None:
+        try:
+            seed = int(seed)
+        except (TypeError, ValueError):
+            return jsonify({"error": "seed must be an integer"}), 400
+
+    MAP_GENERATOR.regenerate(seed=seed)
+    return jsonify(MAP_GENERATOR.serialise())
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=2.3
+noise>=1.2
+pygame>=2.4

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,122 @@
+:root {
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #1f1f1f;
+  color: #f5f5f5;
+}
+
+body {
+  margin: 0;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  min-height: 100vh;
+}
+
+.layout__board {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: #151515;
+  align-items: center;
+  justify-content: center;
+}
+
+.layout__sidebar {
+  padding: 2rem;
+  background: #20242c;
+  box-shadow: inset 1px 0 0 rgba(255, 255, 255, 0.05);
+  overflow-y: auto;
+}
+
+.layout__sidebar h1 {
+  margin-top: 0;
+}
+
+canvas {
+  border: 2px solid #3f3f46;
+  background: #000;
+  max-width: 100%;
+  height: auto;
+}
+
+.toolbar {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 1rem;
+  margin-top: 1rem;
+  border-radius: 999px;
+  background: rgba(17, 17, 23, 0.85);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.45);
+}
+
+.toolbar button {
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  background: #2f2f39;
+  color: #e5e7eb;
+}
+
+.toolbar button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+}
+
+.toolbar button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.toolbar button.is-active {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.toolbar__label {
+  font-size: 0.85rem;
+}
+
+.toolbar__hint {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+#seedInput {
+  width: 6rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.4);
+  color: inherit;
+}
+
+#debugPanel {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 120px;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .layout__sidebar {
+    padding: 1.5rem;
+  }
+
+  .toolbar {
+    flex-wrap: wrap;
+    border-radius: 1rem;
+  }
+}

--- a/static/js/game.js
+++ b/static/js/game.js
@@ -1,0 +1,317 @@
+const canvas = document.getElementById("gameCanvas");
+const ctx = canvas.getContext("2d");
+const spawnButton = document.getElementById("spawnButton");
+const regenerateButton = document.getElementById("regenerateButton");
+const seedInput = document.getElementById("seedInput");
+const debugPanel = document.getElementById("debugPanel");
+
+let mapData = null;
+let tileSize = 4;
+let offsetX = 0;
+let offsetY = 0;
+let spawnMode = false;
+let lastFrameTime = performance.now();
+let lastDebugUpdate = 0;
+
+const units = [];
+let selectedUnitId = null;
+
+class Unit {
+  static nextId = 1;
+
+  constructor(x, y) {
+    this.id = Unit.nextId++;
+    this.x = x;
+    this.y = y;
+    this.targetX = x;
+    this.targetY = y;
+    this.speed = 6; // tiles per second
+  }
+
+  setTarget(tileX, tileY) {
+    this.targetX = tileX;
+    this.targetY = tileY;
+  }
+
+  update(deltaSeconds) {
+    const dx = this.targetX - this.x;
+    const dy = this.targetY - this.y;
+    const distance = Math.hypot(dx, dy);
+    if (distance < 1e-3) {
+      this.x = this.targetX;
+      this.y = this.targetY;
+      return;
+    }
+
+    const step = this.speed * deltaSeconds;
+    if (step >= distance) {
+      this.x = this.targetX;
+      this.y = this.targetY;
+      return;
+    }
+
+    this.x += (dx / distance) * step;
+    this.y += (dy / distance) * step;
+  }
+
+  toDebug() {
+    return {
+      id: this.id,
+      position: {
+        x: Number(this.x.toFixed(2)),
+        y: Number(this.y.toFixed(2)),
+      },
+      target: {
+        x: Number(this.targetX.toFixed(2)),
+        y: Number(this.targetY.toFixed(2)),
+      },
+      selected: this.id === selectedUnitId,
+    };
+  }
+}
+
+function configureCanvas(metadata) {
+  const maxTileWidth = Math.floor(canvas.width / metadata.width);
+  const maxTileHeight = Math.floor(canvas.height / metadata.height);
+  tileSize = Math.max(2, Math.min(maxTileWidth, maxTileHeight));
+
+  const mapWidthPx = metadata.width * tileSize;
+  const mapHeightPx = metadata.height * tileSize;
+  offsetX = Math.floor((canvas.width - mapWidthPx) / 2);
+  offsetY = Math.floor((canvas.height - mapHeightPx) / 2);
+}
+
+function tileTopLeftToCanvas(tileX, tileY) {
+  return {
+    x: offsetX + tileX * tileSize,
+    y: offsetY + tileY * tileSize,
+  };
+}
+
+function worldToCanvas(worldX, worldY) {
+  return {
+    x: offsetX + worldX * tileSize,
+    y: offsetY + worldY * tileSize,
+  };
+}
+
+function canvasToTile(event) {
+  const rect = canvas.getBoundingClientRect();
+  const scaleX = canvas.width / rect.width;
+  const scaleY = canvas.height / rect.height;
+  const canvasX = (event.clientX - rect.left) * scaleX - offsetX;
+  const canvasY = (event.clientY - rect.top) * scaleY - offsetY;
+  return {
+    tileX: Math.floor(canvasX / tileSize),
+    tileY: Math.floor(canvasY / tileSize),
+    rawX: canvasX / tileSize,
+    rawY: canvasY / tileSize,
+  };
+}
+
+function findUnitAt(tileX, tileY) {
+  const targetX = tileX + 0.5;
+  const targetY = tileY + 0.5;
+  return units.find(
+    (unit) => Math.hypot(unit.x - targetX, unit.y - targetY) < 0.5
+  );
+}
+
+function spawnUnit(tileX, tileY) {
+  const unit = new Unit(tileX + 0.5, tileY + 0.5);
+  units.push(unit);
+  selectedUnitId = unit.id;
+  updateDebugPanel(true);
+}
+
+function setSpawnMode(enabled) {
+  spawnMode = enabled;
+  spawnButton.classList.toggle("is-active", spawnMode);
+}
+
+function handleCanvasClick(event) {
+  if (!mapData) {
+    return;
+  }
+
+  const { tileX, tileY } = canvasToTile(event);
+  if (
+    tileX < 0 ||
+    tileY < 0 ||
+    tileX >= mapData.width ||
+    tileY >= mapData.height
+  ) {
+    return;
+  }
+
+  if (spawnMode) {
+    spawnUnit(tileX, tileY);
+    setSpawnMode(false);
+    return;
+  }
+
+  const clickedUnit = findUnitAt(tileX, tileY);
+  if (clickedUnit) {
+    selectedUnitId = clickedUnit.id;
+    updateDebugPanel(true);
+    return;
+  }
+
+  if (selectedUnitId !== null) {
+    const unit = units.find((u) => u.id === selectedUnitId);
+    if (unit) {
+      unit.setTarget(tileX + 0.5, tileY + 0.5);
+      updateDebugPanel(true);
+    }
+  }
+}
+
+async function fetchMap(seed) {
+  const url = seed ? `/api/map?seed=${seed}` : "/api/map";
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load map: ${response.status}`);
+  }
+  return response.json();
+}
+
+async function regenerateMap() {
+  const seedValue = seedInput.value.trim();
+  const payload = {};
+  if (seedValue !== "") {
+    payload.seed = Number(seedValue);
+  }
+
+  const response = await fetch("/api/map/regenerate", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorMessage = await response.text();
+    throw new Error(`Failed to regenerate map: ${errorMessage}`);
+  }
+
+  return response.json();
+}
+
+function drawMap() {
+  if (!mapData) {
+    return;
+  }
+
+  const { tiles, colours, width, height } = mapData;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const terrain = tiles[y][x];
+      ctx.fillStyle = colours[terrain] ?? "#000";
+      const { x: drawX, y: drawY } = tileTopLeftToCanvas(x, y);
+      ctx.fillRect(drawX, drawY, tileSize + 1, tileSize + 1);
+    }
+  }
+}
+
+function drawUnits() {
+  for (const unit of units) {
+    const { x, y } = worldToCanvas(unit.x, unit.y);
+    const radius = Math.max(4, tileSize * 0.35);
+    ctx.beginPath();
+    ctx.fillStyle = "#facc15";
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
+    ctx.fill();
+
+    if (unit.id === selectedUnitId) {
+      ctx.lineWidth = 2;
+      ctx.strokeStyle = "#f87171";
+      ctx.beginPath();
+      ctx.arc(x, y, radius + 3, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+
+    if (Math.abs(unit.targetX - unit.x) > 0.01 || Math.abs(unit.targetY - unit.y) > 0.01) {
+      const target = worldToCanvas(unit.targetX, unit.targetY);
+      ctx.strokeStyle = "rgba(250, 204, 21, 0.65)";
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineTo(target.x, target.y);
+      ctx.stroke();
+
+      ctx.fillStyle = "rgba(34, 197, 94, 0.75)";
+      ctx.beginPath();
+      ctx.arc(target.x, target.y, radius * 0.6, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+}
+
+function drawScene() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawMap();
+  drawUnits();
+}
+
+function updateUnits(deltaSeconds) {
+  for (const unit of units) {
+    unit.update(deltaSeconds);
+  }
+}
+
+function updateDebugPanel(force = false) {
+  const now = performance.now();
+  if (!force && now - lastDebugUpdate < 200) {
+    return;
+  }
+  lastDebugUpdate = now;
+
+  const debugData = {
+    seed: mapData?.seed ?? "n/a",
+    units: units.map((unit) => unit.toDebug()),
+  };
+  debugPanel.textContent = JSON.stringify(debugData, null, 2);
+}
+
+function loop(now) {
+  const deltaSeconds = Math.min((now - lastFrameTime) / 1000, 0.1);
+  lastFrameTime = now;
+  updateUnits(deltaSeconds);
+  drawScene();
+  updateDebugPanel();
+  requestAnimationFrame(loop);
+}
+
+async function initialise() {
+  try {
+    mapData = await fetchMap();
+    configureCanvas(mapData);
+    drawScene();
+    requestAnimationFrame(loop);
+  } catch (error) {
+    console.error(error);
+    debugPanel.textContent = `Failed to start game: ${error.message}`;
+  }
+}
+
+spawnButton.addEventListener("click", () => {
+  setSpawnMode(!spawnMode);
+});
+
+regenerateButton.addEventListener("click", async () => {
+  try {
+    mapData = await regenerateMap();
+    configureCanvas(mapData);
+    units.length = 0;
+    selectedUnitId = null;
+    setSpawnMode(false);
+    drawScene();
+    updateDebugPanel(true);
+  } catch (error) {
+    console.error(error);
+    debugPanel.textContent = `Failed to regenerate map: ${error.message}`;
+  }
+});
+
+canvas.addEventListener("click", handleCanvasClick);
+
+initialise();

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Procedural RTS Prototype</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
+  </head>
+  <body>
+    <main class="layout">
+      <section class="layout__board">
+        <canvas id="gameCanvas" width="960" height="640" aria-label="Game canvas"></canvas>
+        <div class="toolbar" role="toolbar" aria-label="Game controls">
+          <button id="spawnButton" type="button">Spawn unit</button>
+          <button id="regenerateButton" type="button">New world</button>
+          <label class="toolbar__label" for="seedInput">Seed</label>
+          <input id="seedInput" name="seed" type="number" placeholder="Random" />
+          <span class="toolbar__hint">Click a unit to select it, click a tile to move.</span>
+        </div>
+      </section>
+      <aside class="layout__sidebar">
+        <h1>Procedural RTS Prototype</h1>
+        <p>
+          This lightweight prototype ports the procedural terrain explorer to the web.
+          Generate new worlds, spawn explorer units and command them around the map
+          directly in your browser.
+        </p>
+        <section>
+          <h2>How to play</h2>
+          <ol>
+            <li>Press <strong>Spawn unit</strong> and click the map to place explorers.</li>
+            <li>Click a unit to select it. A highlighted outline indicates selection.</li>
+            <li>Click anywhere else on the map to set the selected unit's destination.</li>
+            <li>Use <strong>New world</strong> to regenerate the map. Provide a seed for reproducible results.</li>
+          </ol>
+        </section>
+        <section>
+          <h2>Debug helpers</h2>
+          <p>
+            The panel below mirrors the in-memory game state so it is easier to debug and
+            extend the experience. Use it to verify positions, targets and selection state.
+          </p>
+          <pre id="debugPanel" aria-live="polite"></pre>
+        </section>
+      </aside>
+    </main>
+    <script src="{{ url_for('static', filename='js/game.js') }}" type="module"></script>
+  </body>
+</html>

--- a/web_map_generator.py
+++ b/web_map_generator.py
@@ -1,0 +1,168 @@
+"""Utility to generate terrain maps for the web client.
+
+This module mirrors the high level ideas of the original Pygame based
+map generator but avoids any dependency on pygame so it can safely run
+in a headless web server context.  The generator exposes a small API
+that is convenient both for the Flask endpoints and for unit tests.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence
+import random
+
+import noise
+
+# Default map configuration.  The values can be customised by
+# instantiating :class:`WebMapGenerator` with different parameters.
+DEFAULT_MAP_WIDTH = 128
+DEFAULT_MAP_HEIGHT = 128
+
+# The colour palette is kept in hex so the JavaScript client can use it
+# without additional conversion.
+TERRAIN_COLOURS: Dict[str, str] = {
+    "deep_water": "#00008b",
+    "shallow_water": "#4169e1",
+    "beach": "#eed6af",
+    "grassland": "#228b22",
+    "forest": "#006400",
+    "hills": "#a0522d",
+    "mountains": "#8b8989",
+    "snow_peaks": "#fffafa",
+}
+
+
+@dataclass(frozen=True)
+class Tile:
+    """Light-weight representation of a tile in the generated map."""
+
+    x: int
+    y: int
+    terrain: str
+
+
+class WebMapGenerator:
+    """Generate 2D terrain maps using Perlin noise.
+
+    The generator is intentionally deterministic for a given seed so the
+    front end can request a new map with predictable results.  The
+    implementation borrows the biome thresholds from the original
+    ``map_generator`` module while staying independent from pygame.
+    """
+
+    def __init__(
+        self,
+        width: int = DEFAULT_MAP_WIDTH,
+        height: int = DEFAULT_MAP_HEIGHT,
+        *,
+        seed: int | None = None,
+    ) -> None:
+        if width <= 0 or height <= 0:
+            raise ValueError("width and height must be positive integers")
+
+        self.width = width
+        self.height = height
+        self.seed = random.randint(0, 1000) if seed is None else seed
+        self._tiles: List[List[Tile]] | None = None
+
+    # ------------------------------------------------------------------
+    # Map generation helpers
+    # ------------------------------------------------------------------
+    def _get_elevation(self, x: int, y: int) -> float:
+        return noise.pnoise2(
+            x / self.width,
+            y / self.height,
+            octaves=6,
+            persistence=0.5,
+            lacunarity=2.0,
+            repeatx=1024,
+            repeaty=1024,
+            base=self.seed,
+        )
+
+    def _get_moisture(self, x: int, y: int) -> float:
+        return noise.pnoise2(
+            x / self.width,
+            y / self.height,
+            octaves=4,
+            persistence=0.6,
+            lacunarity=2.0,
+            repeatx=1024,
+            repeaty=1024,
+            base=self.seed + 1,
+        )
+
+    @staticmethod
+    def _classify_terrain(elevation: float, moisture: float) -> str:
+        if elevation < -0.3:
+            return "deep_water"
+        if elevation < -0.1:
+            return "shallow_water"
+        if elevation < 0.0:
+            return "beach"
+        if elevation < 0.3:
+            return "grassland" if moisture < 0 else "forest"
+        if elevation < 0.6:
+            return "hills"
+        if elevation < 0.8:
+            return "mountains"
+        return "snow_peaks"
+
+    def _ensure_map_generated(self) -> None:
+        if self._tiles is not None:
+            return
+
+        tiles: List[List[Tile]] = []
+        for y in range(self.height):
+            row: List[Tile] = []
+            for x in range(self.width):
+                elevation = self._get_elevation(x, y)
+                moisture = self._get_moisture(x, y)
+                terrain = self._classify_terrain(elevation, moisture)
+                row.append(Tile(x=x, y=y, terrain=terrain))
+            tiles.append(row)
+        self._tiles = tiles
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get_tiles(self) -> Sequence[Sequence[Tile]]:
+        """Return the generated tile grid.
+
+        The map is generated lazily, ensuring that instantiation is
+        inexpensive if the caller only needs metadata.  The returned
+        structure is immutable from the caller's perspective, but the
+        actual :class:`Tile` objects are shared to minimise allocations.
+        """
+
+        self._ensure_map_generated()
+        assert self._tiles is not None
+        return self._tiles
+
+    def serialise(self) -> Dict[str, object]:
+        """Return a JSON-serialisable representation of the map."""
+
+        tiles = self.get_tiles()
+        return {
+            "width": self.width,
+            "height": self.height,
+            "seed": self.seed,
+            "tiles": [[tile.terrain for tile in row] for row in tiles],
+            "colours": TERRAIN_COLOURS,
+        }
+
+    def regenerate(self, *, seed: int | None = None) -> None:
+        """Invalidate the cached map and build a new one.
+
+        Parameters
+        ----------
+        seed:
+            Optional seed to use for the next generation.  If ``None`` the
+            generator picks a new random seed.
+        """
+
+        self.seed = random.randint(0, 1000) if seed is None else seed
+        self._tiles = None
+
+
+__all__ = ["Tile", "WebMapGenerator", "TERRAIN_COLOURS"]


### PR DESCRIPTION
## Summary
- add a Flask entrypoint that serves the RTS prototype as a browser-based experience and exposes map APIs
- implement a headless Perlin noise map generator tailored for the web workflow
- build HTML/CSS/JS front-end assets for spawning and commanding units along with updated documentation and dependencies

## Testing
- python -m compileall app.py web_map_generator.py static/js/game.js

------
https://chatgpt.com/codex/tasks/task_e_68ceefca0e04832c9f6764157dfee7ff