### PR TITLE
Add Nova Frontier web RTS experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ The dependencies include tooling for tests and legacy rendering
 experiments. They are lightweight and allow you to run the backend demo
 as well as revisit the earlier Pygame prototypes if desired.
 
+## Running the Nova Frontier web app
+
+Install the dependencies and launch the FastAPI application with Uvicorn:
+
+```
+uvicorn webapp.server:app --reload --host 0.0.0.0 --port 8000
+```
+
+Open <http://localhost:8000> in two browser windows and join the skirmish with
+your preferred callsigns. Commands are issued by left-clicking to select a unit
+and right-clicking the battlefield to move or attack. Production buttons on the
+left panel queue harvesters and infantry.
+
 ## Running the demo
 
 With the environment prepared, execute the main entry point:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nova Frontier RTS</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="toolbar">
+      <div class="branding">
+        <h1>Nova Frontier</h1>
+        <p class="tagline">Web-based RTS skirmish inspired by the classics.</p>
+      </div>
+      <div class="controls">
+        <label for="player-name">Callsign</label>
+        <input id="player-name" type="text" maxlength="18" value="Commander" />
+        <button id="join-button">Join Skirmish</button>
+      </div>
+      <div class="resources">
+        <div>Credits: <span id="credits">0</span></div>
+        <div>Status: <span id="status">Idle</span></div>
+      </div>
+    </header>
+
+    <main class="layout">
+      <aside class="sidebar">
+        <section>
+          <h2>Production</h2>
+          <button data-command="build" data-type="harvester">Train Harvester</button>
+          <button data-command="build" data-type="infantry">Train Infantry</button>
+        </section>
+        <section>
+          <h2>Orders</h2>
+          <p>Select a unit in the battlefield and right click to issue orders.</p>
+        </section>
+        <section class="legend">
+          <h2>Legend</h2>
+          <ul>
+            <li><span class="legend-icon resource"></span> Resource field</li>
+            <li><span class="legend-icon base"></span> Base</li>
+            <li><span class="legend-icon infantry"></span> Infantry</li>
+            <li><span class="legend-icon harvester"></span> Harvester</li>
+          </ul>
+        </section>
+      </aside>
+      <section class="battlefield">
+        <canvas id="battle-canvas" width="960" height="720"></canvas>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        Built as a proof of concept for a browser-playable RTS. Share the URL
+        with a friend to battle in real time!
+      </p>
+    </footer>
+
+    <script type="module" src="/static/main.js"></script>
+  </body>
+</html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,241 @@
+const joinButton = document.getElementById("join-button");
+const nameInput = document.getElementById("player-name");
+const statusSpan = document.getElementById("status");
+const creditsSpan = document.getElementById("credits");
+const canvas = document.getElementById("battle-canvas");
+const ctx = canvas.getContext("2d");
+
+let websocket = null;
+let playerId = null;
+let playerColor = "#ffffff";
+let lastState = null;
+let selection = null;
+let animationHandle = null;
+
+const commandButtons = document.querySelectorAll("[data-command]");
+
+function connect() {
+  if (websocket && websocket.readyState === WebSocket.OPEN) {
+    return;
+  }
+  const name = nameInput.value.trim() || "Commander";
+  const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+  const socketUrl = `${protocol}://${window.location.host}/ws?name=${encodeURIComponent(
+    name
+  )}`;
+  websocket = new WebSocket(socketUrl);
+  statusSpan.textContent = "Connecting";
+
+  websocket.addEventListener("open", () => {
+    joinButton.disabled = true;
+    statusSpan.textContent = "Matchmaking";
+  });
+
+  websocket.addEventListener("message", (event) => {
+    const data = JSON.parse(event.data);
+    if (data.type === "welcome") {
+      playerId = data.player.id;
+      playerColor = data.player.color;
+      statusSpan.textContent = "Awaiting opponent";
+      return;
+    }
+    if (data.type === "state") {
+      lastState = data.state;
+      updateUi();
+      if (!animationHandle) {
+        animationHandle = requestAnimationFrame(renderLoop);
+      }
+      if (data.state.winner) {
+        statusSpan.textContent =
+          data.state.winner === playerId ? "Victory" : "Defeat";
+      }
+    }
+  });
+
+  websocket.addEventListener("close", () => {
+    joinButton.disabled = false;
+    statusSpan.textContent = "Disconnected";
+    playerId = null;
+    lastState = null;
+    if (animationHandle) {
+      cancelAnimationFrame(animationHandle);
+      animationHandle = null;
+    }
+    clearCanvas();
+  });
+
+  websocket.addEventListener("error", () => {
+    statusSpan.textContent = "Connection error";
+  });
+}
+
+joinButton.addEventListener("click", connect);
+
+commandButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    if (!websocket || websocket.readyState !== WebSocket.OPEN) return;
+    const payload = { type: button.dataset.type };
+    websocket.send(
+      JSON.stringify({
+        action: button.dataset.command,
+        payload,
+      })
+    );
+  });
+});
+
+canvas.addEventListener("click", (event) => {
+  if (!lastState || !playerId) return;
+  const pos = canvasToWorld(event.offsetX, event.offsetY);
+  const myUnits = lastState.players[playerId]?.units ?? [];
+  const hitUnit = myUnits.find((unit) => distance(unit, pos) < 1.5);
+  if (hitUnit) {
+    selection = hitUnit.id;
+  }
+});
+
+canvas.addEventListener("contextmenu", (event) => {
+  event.preventDefault();
+  if (!lastState || !playerId || selection === null) return;
+  if (!websocket || websocket.readyState !== WebSocket.OPEN) return;
+  const worldPos = canvasToWorld(event.offsetX, event.offsetY);
+  const enemyUnit = findEnemyAt(worldPos);
+  if (enemyUnit) {
+    websocket.send(
+      JSON.stringify({
+        action: "attack",
+        payload: { unit: selection, target: enemyUnit.id },
+      })
+    );
+  } else {
+    websocket.send(
+      JSON.stringify({
+        action: "move",
+        payload: { unit: selection, position: [worldPos.x, worldPos.y] },
+      })
+    );
+  }
+});
+
+function updateUi() {
+  if (!lastState || !playerId) return;
+  const player = lastState.players[playerId];
+  creditsSpan.textContent = player ? player.credits : 0;
+  if (player && player.base) {
+    statusSpan.textContent = "In combat";
+  }
+}
+
+function renderLoop() {
+  clearCanvas();
+  if (lastState) {
+    drawGrid();
+    drawResources();
+    drawPlayers();
+  }
+  animationHandle = requestAnimationFrame(renderLoop);
+}
+
+function clearCanvas() {
+  ctx.fillStyle = "#030712";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+}
+
+function drawGrid() {
+  const mapWidth = lastState.config.map[0];
+  const mapHeight = lastState.config.map[1];
+  const scale = getScale();
+  ctx.strokeStyle = "rgba(148, 163, 184, 0.1)";
+  ctx.lineWidth = 1;
+  for (let x = 0; x <= mapWidth; x += 5) {
+    ctx.beginPath();
+    ctx.moveTo(x * scale.x, 0);
+    ctx.lineTo(x * scale.x, canvas.height);
+    ctx.stroke();
+  }
+  for (let y = 0; y <= mapHeight; y += 5) {
+    ctx.beginPath();
+    ctx.moveTo(0, y * scale.y);
+    ctx.lineTo(canvas.width, y * scale.y);
+    ctx.stroke();
+  }
+}
+
+function drawResources() {
+  const scale = getScale();
+  ctx.fillStyle = "#facc15";
+  lastState.resources.forEach((node) => {
+    ctx.beginPath();
+    ctx.arc(node.x * scale.x, node.y * scale.y, 6, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function drawPlayers() {
+  const scale = getScale();
+  Object.values(lastState.players).forEach((player) => {
+    if (player.base) {
+      ctx.fillStyle = player.color;
+      ctx.fillRect(
+        player.base.x * scale.x - 10,
+        player.base.y * scale.y - 10,
+        20,
+        20
+      );
+    }
+    player.units.forEach((unit) => {
+      const radius = unit.unit_type === "harvester" ? 7 : 5;
+      ctx.beginPath();
+      ctx.fillStyle = player.color;
+      ctx.arc(unit.x * scale.x, unit.y * scale.y, radius, 0, Math.PI * 2);
+      ctx.fill();
+      if (player.id === playerId && unit.id === selection) {
+        ctx.strokeStyle = "#ffffff";
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(unit.x * scale.x, unit.y * scale.y, radius + 4, 0, Math.PI * 2);
+        ctx.stroke();
+      }
+    });
+  });
+}
+
+function getScale() {
+  if (!lastState) return { x: 1, y: 1 };
+  const mapWidth = lastState.config.map[0];
+  const mapHeight = lastState.config.map[1];
+  return {
+    x: canvas.width / mapWidth,
+    y: canvas.height / mapHeight,
+  };
+}
+
+function canvasToWorld(x, y) {
+  const scale = getScale();
+  return { x: x / scale.x, y: y / scale.y };
+}
+
+function distance(unit, pos) {
+  const dx = unit.x - pos.x;
+  const dy = unit.y - pos.y;
+  return Math.hypot(dx, dy);
+}
+
+function findEnemyAt(pos) {
+  if (!lastState || !playerId) return null;
+  for (const player of Object.values(lastState.players)) {
+    if (player.id === playerId) continue;
+    for (const unit of player.units) {
+      if (distance(unit, pos) < 1.25) {
+        return unit;
+      }
+    }
+  }
+  return null;
+}
+
+window.addEventListener("beforeunload", () => {
+  if (websocket && websocket.readyState === WebSocket.OPEN) {
+    websocket.close();
+  }
+});

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,161 @@
+:root {
+  font-family: "Segoe UI", Roboto, sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+body {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: linear-gradient(90deg, #1d4ed8, #312e81);
+  box-shadow: 0 2px 12px rgba(15, 23, 42, 0.6);
+}
+
+.branding h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.branding .tagline {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}
+
+.controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.controls input {
+  padding: 0.4rem 0.6rem;
+  border-radius: 4px;
+  border: none;
+}
+
+.controls button {
+  padding: 0.45rem 0.9rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #22c55e;
+  color: #04131f;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.controls button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(34, 197, 94, 0.4);
+}
+
+.resources {
+  text-align: right;
+  line-height: 1.4;
+}
+
+.layout {
+  flex: 1;
+  display: flex;
+}
+
+.sidebar {
+  width: 260px;
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(6px);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-right: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.sidebar section h2 {
+  margin-top: 0;
+}
+
+.sidebar button {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #38bdf8;
+  color: #02131f;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.sidebar button:hover {
+  background-color: #0ea5e9;
+}
+
+.legend ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.legend-icon {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.legend-icon.resource {
+  background-color: #facc15;
+}
+
+.legend-icon.base {
+  background-color: #f97316;
+}
+
+.legend-icon.infantry {
+  background-color: #38bdf8;
+}
+
+.legend-icon.harvester {
+  background-color: #a3e635;
+}
+
+.battlefield {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-image: radial-gradient(circle at center, rgba(59, 130, 246, 0.15), transparent 65%);
+}
+
+#battle-canvas {
+  border: 2px solid rgba(148, 163, 184, 0.35);
+  border-radius: 4px;
+  background-color: #030712;
+}
+
+footer {
+  padding: 1rem 2rem;
+  background: rgba(15, 23, 42, 0.85);
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  text-align: center;
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pytest>=7.0
 pygame>=2.1
 noise>=1.2
+fastapi>=0.100
+uvicorn[standard]>=0.23

--- a/tests/test_web_engine.py
+++ b/tests/test_web_engine.py
@@ -1,0 +1,44 @@
+"""Regression tests for the web-facing RTS engine."""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from webapp import config
+from webapp.engine import GameEngine
+from webapp.models import Command, Player, PlayerColor, UnitType
+
+
+@pytest.fixture()
+def engine() -> GameEngine:
+    players = {
+        "p1": Player(id="p1", name="Tester 1", color=PlayerColor.BLUE),
+        "p2": Player(id="p2", name="Tester 2", color=PlayerColor.RED),
+    }
+    return GameEngine(seed=42, players=players)
+
+
+def test_building_units_consumes_credits(engine: GameEngine) -> None:
+    player = engine.state.players["p1"]
+    starting = player.credits
+    engine.queue_command(
+        Command(player_id="p1", action="build", payload={"type": UnitType.INFANTRY.value}, issued_at=0.0)
+    )
+    engine._tick(1.0)
+    assert player.credits == starting - config.UNIT_COST
+    # Advance time to finish production.
+    for _ in range(int(math.ceil(config.UNIT_BUILD_TIME)) + 1):
+        engine._tick(1.0)
+    assert any(unit.unit_type == UnitType.INFANTRY for unit in player.units.values())
+
+
+def test_harvesters_generate_income(engine: GameEngine) -> None:
+    player = engine.state.players["p1"]
+    harvester = next(unit for unit in player.units.values() if unit.unit_type == UnitType.HARVESTER)
+    original_credits = player.credits
+    # Simulate a few harvest cycles.
+    for _ in range(40):
+        engine._tick(0.5)
+    assert player.credits > original_credits
+    assert harvester.carrying >= 0

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -1,0 +1,48 @@
+"""Configuration constants for the web RTS server.
+
+All numeric values can be tuned to adjust the pacing of the match. The
+settings have been chosen to roughly emulate the gathering rate and combat
+speed of classic RTS titles while keeping the implementation simple.
+"""
+
+TICK_RATE = 10  # Simulation ticks per second.
+
+MAP_WIDTH = 80
+MAP_HEIGHT = 60
+TILE_SIZE = 16  # Size of a tile in client side pixels.
+
+STARTING_CREDITS = 500
+CREDIT_CAP = 5000
+
+RESOURCE_NODE_COUNT = 12
+RESOURCE_NODE_VALUE = 2000
+HARVEST_RATE = 20  # Credits per harvest action.
+HARVEST_TIME = 3.0  # Seconds per harvest cycle.
+
+UNIT_BUILD_TIME = 5.0  # Seconds to produce a combat unit.
+UNIT_COST = 150
+UNIT_SPEED = 5.0  # Tiles per second.
+UNIT_ATTACK_RANGE = 4.0
+UNIT_ATTACK_DAMAGE = 10
+UNIT_ATTACK_COOLDOWN = 1.5
+UNIT_MAX_HEALTH = 100
+
+HARVESTER_COST = 250
+HARVESTER_BUILD_TIME = 6.0
+HARVESTER_SPEED = 4.0
+HARVESTER_MAX_HEALTH = 120
+
+BASE_MAX_HEALTH = 1000
+BASE_ATTACK_RANGE = 8.0
+BASE_ATTACK_DAMAGE = 25
+BASE_ATTACK_COOLDOWN = 2.5
+
+# Networking configuration.
+MATCHMAKING_TIMEOUT = 30.0  # Seconds to wait for an opponent before bot fill.
+MAX_PLAYERS_PER_MATCH = 2
+
+# Client configuration hints.
+GAME_NAME = "Nova Frontier"
+LOBBY_WELCOME_MESSAGE = (
+    "Welcome commander! Gather Tiberite shards, raise an army and crush the opposition."
+)

--- a/webapp/engine.py
+++ b/webapp/engine.py
@@ -1,0 +1,382 @@
+"""Real time simulation engine for Nova Frontier.
+
+The engine keeps the authoritative state of a match, runs a fixed tick loop and
+processes player commands.  It is intentionally deterministic to simplify
+synchronisation across WebSocket clients.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import math
+import random
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Deque, Dict, Iterable, List, Optional
+
+from . import config
+from .models import (
+    Base,
+    Command,
+    GameState,
+    MatchView,
+    Player,
+    PlayerColor,
+    ResourceNode,
+    Unit,
+    UnitType,
+    Vector2,
+)
+
+
+@dataclass(slots=True)
+class CommandQueue:
+    """Thread-safe queue used to stage player commands until the next tick."""
+
+    _queue: Deque[Command] = field(default_factory=deque)
+
+    def push(self, command: Command) -> None:
+        self._queue.append(command)
+
+    def drain(self) -> List[Command]:
+        commands = list(self._queue)
+        self._queue.clear()
+        return commands
+
+
+class GameEngine:
+    """Simulation core responsible for executing one RTS match."""
+
+    def __init__(self, seed: Optional[int] = None, players: Optional[Dict[str, Player]] = None) -> None:
+        self.random = random.Random(seed)
+        self.command_queue = CommandQueue()
+        self.state = self._initial_state(players)
+        self._tick_interval = 1.0 / config.TICK_RATE
+        self._tick_task: Optional[asyncio.Task[None]] = None
+        self._subscribers: List[asyncio.Queue[MatchView]] = []
+
+    # ------------------------------------------------------------------
+    # State initialization
+    # ------------------------------------------------------------------
+    def _initial_state(self, provided_players: Optional[Dict[str, Player]]) -> GameState:
+        if provided_players is None:
+            colors = list(PlayerColor)
+            self.random.shuffle(colors)
+            provided_players = {
+                "p1": Player(id="p1", name="Player 1", color=colors[0]),
+                "p2": Player(id="p2", name="Player 2", color=colors[1]),
+            }
+        players = {pid: player for pid, player in provided_players.items()}
+        self._spawn_bases(players)
+        resource_nodes = self._spawn_resources()
+        return GameState(players=players, resource_nodes=resource_nodes)
+
+    def _spawn_bases(self, players: Dict[str, Player]) -> None:
+        placements = [(8, config.MAP_HEIGHT // 2), (config.MAP_WIDTH - 8, config.MAP_HEIGHT // 2)]
+        for idx, (player, position) in enumerate(zip(players.values(), placements)):
+            player.base = Base(id=idx + 1, owner_id=player.id, position=position)
+            # Every player starts with one harvester.
+            unit_id = self._generate_unit_id(player)
+            player.units[unit_id] = Unit(
+                id=unit_id,
+                owner_id=player.id,
+                unit_type=UnitType.HARVESTER,
+                position=(position[0] + self.random.uniform(-2, 2), position[1] + self.random.uniform(-2, 2)),
+                health=config.HARVESTER_MAX_HEALTH,
+            )
+
+    def _spawn_resources(self) -> Dict[int, ResourceNode]:
+        nodes: Dict[int, ResourceNode] = {}
+        margin = 10
+        for idx in range(config.RESOURCE_NODE_COUNT):
+            position = (
+                self.random.randint(margin, config.MAP_WIDTH - margin),
+                self.random.randint(margin, config.MAP_HEIGHT - margin),
+            )
+            nodes[idx] = ResourceNode(id=idx, position=position)
+        return nodes
+
+    # ------------------------------------------------------------------
+    # Simulation loop
+    # ------------------------------------------------------------------
+    async def start(self) -> None:
+        if self._tick_task is None:
+            self._tick_task = asyncio.create_task(self._run_loop())
+
+    async def wait_until_finished(self) -> None:
+        if self._tick_task is not None:
+            await self._tick_task
+
+    async def stop(self) -> None:
+        if self._tick_task:
+            self._tick_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._tick_task
+            self._tick_task = None
+
+    async def _run_loop(self) -> None:
+        last_tick = time.perf_counter()
+        while self.state.winner is None:
+            now = time.perf_counter()
+            dt = now - last_tick
+            if dt < self._tick_interval:
+                await asyncio.sleep(self._tick_interval - dt)
+                continue
+            last_tick = now
+            events = self._tick(dt)
+            await self._notify_subscribers(events)
+
+    def _tick(self, dt: float) -> List[Dict[str, object]]:
+        self.state.time_elapsed += dt
+        commands = self.command_queue.drain()
+        events: List[Dict[str, object]] = []
+        for command in commands:
+            events.extend(self._execute_command(command))
+        self._update_units(dt, events)
+        self._update_bases(dt, events)
+        self._determine_winner(events)
+        return events
+
+    async def _notify_subscribers(self, events: List[Dict[str, object]]) -> None:
+        view = MatchView(state=self.state, events=events)
+        for queue in list(self._subscribers):
+            if queue.full():
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    queue.get_nowait()
+            await queue.put(view)
+
+    def subscribe(self) -> asyncio.Queue[MatchView]:
+        """Create a queue that will receive every state update."""
+
+        queue: asyncio.Queue[MatchView] = asyncio.Queue(maxsize=1)
+        self._subscribers.append(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue[MatchView]) -> None:
+        with contextlib.suppress(ValueError):
+            self._subscribers.remove(queue)
+
+    # ------------------------------------------------------------------
+    # Command handling
+    # ------------------------------------------------------------------
+    def queue_command(self, command: Command) -> None:
+        self.command_queue.push(command)
+
+    def _execute_command(self, command: Command) -> List[Dict[str, object]]:
+        handler_name = f"_handle_{command.action}"
+        handler = getattr(self, handler_name, None)
+        if handler is None:
+            return [{"type": "error", "message": f"Unknown command {command.action}"}]
+        return handler(command)
+
+    def _handle_move(self, command: Command) -> List[Dict[str, object]]:
+        unit_id = int(command.payload.get("unit"))
+        position = command.payload.get("position")
+        player = self.state.players.get(command.player_id)
+        if not player or unit_id not in player.units or not position:
+            return []
+        player.units[unit_id].target_position = tuple(position)
+        player.units[unit_id].target_unit = None
+        return [{"type": "order", "unit": unit_id, "position": position}]
+
+    def _handle_attack(self, command: Command) -> List[Dict[str, object]]:
+        unit_id = int(command.payload.get("unit"))
+        target_id = int(command.payload.get("target"))
+        player = self.state.players.get(command.player_id)
+        if not player or unit_id not in player.units:
+            return []
+        player.units[unit_id].target_unit = target_id
+        return [{"type": "order", "unit": unit_id, "target": target_id}]
+
+    def _handle_build(self, command: Command) -> List[Dict[str, object]]:
+        unit_type = command.payload.get("type")
+        player = self.state.players.get(command.player_id)
+        if player is None:
+            return []
+        if unit_type == UnitType.INFANTRY.value and player.credits >= config.UNIT_COST:
+            player.credits -= config.UNIT_COST
+            unit_id = self._generate_unit_id(player)
+            player.units[unit_id] = Unit(
+                id=unit_id,
+                owner_id=player.id,
+                unit_type=UnitType.INFANTRY,
+                position=self._spawn_near_base(player),
+                health=config.UNIT_MAX_HEALTH,
+                progress=-config.UNIT_BUILD_TIME,
+            )
+            return [{"type": "build", "unit": unit_id, "unit_type": UnitType.INFANTRY.value}]
+        if unit_type == UnitType.HARVESTER.value and player.credits >= config.HARVESTER_COST:
+            player.credits -= config.HARVESTER_COST
+            unit_id = self._generate_unit_id(player)
+            player.units[unit_id] = Unit(
+                id=unit_id,
+                owner_id=player.id,
+                unit_type=UnitType.HARVESTER,
+                position=self._spawn_near_base(player),
+                health=config.HARVESTER_MAX_HEALTH,
+                progress=-config.HARVESTER_BUILD_TIME,
+            )
+            return [{"type": "build", "unit": unit_id, "unit_type": UnitType.HARVESTER.value}]
+        return []
+
+    def _generate_unit_id(self, player: Player) -> int:
+        return max(player.units.keys(), default=0) + 1
+
+    def _spawn_near_base(self, player: Player) -> Vector2:
+        if not player.base:
+            return (config.MAP_WIDTH / 2, config.MAP_HEIGHT / 2)
+        px, py = player.base.position
+        return (px + self.random.uniform(-2, 2), py + self.random.uniform(-2, 2))
+
+    # ------------------------------------------------------------------
+    # Unit and base updates
+    # ------------------------------------------------------------------
+    def _update_units(self, dt: float, events: List[Dict[str, object]]) -> None:
+        for player in self.state.players.values():
+            for unit in list(player.units.values()):
+                if unit.progress < 0:
+                    unit.progress += dt
+                    if unit.progress < 0:
+                        continue
+                if unit.unit_type == UnitType.HARVESTER:
+                    self._update_harvester(unit, player, dt, events)
+                else:
+                    self._update_infantry(unit, player, dt, events)
+
+    def _update_harvester(self, unit: Unit, player: Player, dt: float, events: List[Dict[str, object]]) -> None:
+        if unit.target_position is None:
+            node = self._find_closest_resource(unit.position)
+            if node:
+                unit.target_position = node.position
+        self._move_towards(unit, dt, config.HARVESTER_SPEED)
+        if unit.target_position and self._distance(unit.position, unit.target_position) < 0.5:
+            node = self._resource_at(unit.target_position)
+            if node and node.value_remaining > 0:
+                gathered = node.take(config.HARVEST_RATE)
+                unit.carrying += gathered
+                unit.progress += dt
+                if unit.progress >= config.HARVEST_TIME:
+                    unit.progress = 0.0
+                    unit.target_position = player.base.position if player.base else None
+            elif player.base and self._distance(unit.position, player.base.position) < 1.5:
+                if unit.carrying:
+                    player.credits = min(config.CREDIT_CAP, player.credits + unit.carrying)
+                    events.append({"type": "deposit", "player": player.id, "amount": unit.carrying})
+                    unit.carrying = 0
+                unit.target_position = None
+
+    def _update_infantry(self, unit: Unit, player: Player, dt: float, events: List[Dict[str, object]]) -> None:
+        target_unit = self._find_unit_by_id(unit.target_unit)
+        if target_unit:
+            unit.target_position = target_unit.position
+        self._move_towards(unit, dt, config.UNIT_SPEED)
+        attack_performed = False
+        if target_unit and self._distance(unit.position, target_unit.position) <= config.UNIT_ATTACK_RANGE:
+            if unit.cooldown <= 0:
+                damage = config.UNIT_ATTACK_DAMAGE
+                self._apply_damage(target_unit, damage, events, source=unit.id)
+                unit.cooldown = config.UNIT_ATTACK_COOLDOWN
+                attack_performed = True
+        enemy_base = self._closest_enemy_base(player.id, unit.position)
+        if enemy_base and self._distance(unit.position, enemy_base.position) <= config.UNIT_ATTACK_RANGE:
+            if unit.cooldown <= 0 and not attack_performed:
+                self._apply_base_damage(enemy_base, config.UNIT_ATTACK_DAMAGE, events, source=unit.id)
+                unit.cooldown = config.UNIT_ATTACK_COOLDOWN
+        unit.cooldown = max(0.0, unit.cooldown - dt)
+
+    def _update_bases(self, dt: float, events: List[Dict[str, object]]) -> None:
+        for player in self.state.players.values():
+            base = player.base
+            if not base:
+                continue
+            base.cooldown = max(0.0, base.cooldown - dt)
+            enemy_units = [unit for other in self.state.players.values() if other.id != player.id for unit in other.units.values()]
+            target = self._closest_enemy_unit(base.position, enemy_units)
+            if target and self._distance(base.position, target.position) <= config.BASE_ATTACK_RANGE:
+                if base.cooldown <= 0:
+                    self._apply_damage(target, config.BASE_ATTACK_DAMAGE, events, source=base.id)
+                    base.cooldown = config.BASE_ATTACK_COOLDOWN
+
+    # ------------------------------------------------------------------
+    # Helper routines
+    # ------------------------------------------------------------------
+    def _move_towards(self, unit: Unit, dt: float, speed: float) -> None:
+        if unit.target_position is None:
+            return
+        ux, uy = unit.position
+        tx, ty = unit.target_position
+        dx, dy = tx - ux, ty - uy
+        distance = math.hypot(dx, dy)
+        if distance < 0.01:
+            unit.position = (tx, ty)
+            return
+        step = min(distance, speed * dt)
+        unit.position = (ux + dx / distance * step, uy + dy / distance * step)
+
+    def _distance(self, a: Vector2, b: Vector2) -> float:
+        return math.hypot(a[0] - b[0], a[1] - b[1])
+
+    def _find_closest_resource(self, position: Vector2) -> Optional[ResourceNode]:
+        return min(self.state.resource_nodes.values(), key=lambda node: self._distance(position, node.position), default=None)
+
+    def _resource_at(self, position: Vector2) -> Optional[ResourceNode]:
+        for node in self.state.resource_nodes.values():
+            if self._distance(node.position, position) < 1.0:
+                return node
+        return None
+
+    def _apply_damage(self, unit: Unit, damage: int, events: List[Dict[str, object]], source: int) -> None:
+        unit.health -= damage
+        events.append({"type": "damage", "target": unit.id, "amount": damage, "source": source})
+        if unit.health <= 0:
+            owner = self.state.players[unit.owner_id]
+            del owner.units[unit.id]
+            events.append({"type": "destroyed", "unit": unit.id})
+
+    def _closest_enemy_unit(self, position: Vector2, units: Iterable[Unit]) -> Optional[Unit]:
+        best: Optional[Unit] = None
+        best_distance = float("inf")
+        for unit in units:
+            distance = self._distance(position, unit.position)
+            if distance < best_distance:
+                best = unit
+                best_distance = distance
+        return best
+
+    def _closest_enemy_base(self, player_id: str, position: Vector2) -> Optional[Base]:
+        best: Optional[Base] = None
+        best_distance = float("inf")
+        for other in self.state.players.values():
+            if other.id == player_id or other.base is None:
+                continue
+            distance = self._distance(position, other.base.position)
+            if distance < best_distance:
+                best = other.base
+                best_distance = distance
+        return best
+
+    def _apply_base_damage(self, base: Base, damage: int, events: List[Dict[str, object]], source: int) -> None:
+        base.health -= damage
+        events.append({"type": "base_damage", "target": base.owner_id, "amount": damage, "source": source})
+        if base.health <= 0:
+            owner = self.state.players[base.owner_id]
+            owner.base = None
+            events.append({"type": "base_destroyed", "player": owner.id})
+
+    def _find_unit_by_id(self, unit_id: Optional[int]) -> Optional[Unit]:
+        if unit_id is None:
+            return None
+        for player in self.state.players.values():
+            if unit_id in player.units:
+                return player.units[unit_id]
+        return None
+
+    def _determine_winner(self, events: List[Dict[str, object]]) -> None:
+        alive_players = [player for player in self.state.players.values() if player.base and player.base.health > 0]
+        if len(alive_players) == 1:
+            self.state.winner = alive_players[0].id
+            events.append({"type": "victory", "player": self.state.winner})
+
+
+__all__ = ["GameEngine", "CommandQueue"]

--- a/webapp/matchmaking.py
+++ b/webapp/matchmaking.py
@@ -1,0 +1,150 @@
+"""Matchmaking utilities and WebSocket session orchestration."""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from fastapi import WebSocket
+from fastapi.websockets import WebSocketDisconnect
+
+from . import config
+from .engine import GameEngine
+from .models import Command, MatchView, Player, PlayerColor
+
+
+@dataclass(slots=True)
+class PlayerConnection:
+    """State bound to an active websocket client."""
+
+    websocket: WebSocket
+    player: Player
+    match_ready: asyncio.Future["Match"] = field(default_factory=asyncio.Future)
+
+
+class Match:
+    """Wrapper that binds ``GameEngine`` to a set of websocket clients."""
+
+    def __init__(self, connections: List[PlayerConnection]) -> None:
+        self.connections = connections
+        players: Dict[str, Player] = {conn.player.id: conn.player for conn in connections}
+        self.engine = GameEngine(seed=int(time.time()), players=players)
+        self._runner: Optional[asyncio.Task[None]] = None
+
+    async def start(self) -> None:
+        await self.engine.start()
+        self._runner = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        subscriber_tasks = []
+        listener_tasks = []
+        try:
+            for connection in self.connections:
+                queue = self.engine.subscribe()
+                subscriber_tasks.append(asyncio.create_task(self._dispatch_updates(connection, queue)))
+                listener_tasks.append(asyncio.create_task(self._receive_commands(connection)))
+            await self.engine.wait_until_finished()
+        finally:
+            for task in listener_tasks + subscriber_tasks:
+                task.cancel()
+            await asyncio.gather(*listener_tasks, *subscriber_tasks, return_exceptions=True)
+            await self.engine.stop()
+
+    async def _dispatch_updates(self, connection: PlayerConnection, queue: asyncio.Queue[MatchView]) -> None:
+        websocket = connection.websocket
+        try:
+            await websocket.send_json(
+                {
+                    "type": "welcome",
+                    "player": {
+                        "id": connection.player.id,
+                        "name": connection.player.name,
+                        "color": connection.player.color.value,
+                    },
+                    "message": config.LOBBY_WELCOME_MESSAGE,
+                }
+            )
+            while True:
+                view = await queue.get()
+                payload = view.serialise()
+                payload["type"] = "state"
+                await websocket.send_json(payload)
+                if view.state.winner is not None:
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive logging hook
+            await websocket.close(code=1011, reason=f"Server error: {exc}")
+            raise
+        finally:
+            self.engine.unsubscribe(queue)
+
+    async def _receive_commands(self, connection: PlayerConnection) -> None:
+        websocket = connection.websocket
+        try:
+            while True:
+                message = await websocket.receive_json()
+                command = Command(
+                    player_id=connection.player.id,
+                    action=message.get("action", ""),
+                    payload=message.get("payload", {}),
+                    issued_at=time.time(),
+                )
+                self.engine.queue_command(command)
+        except asyncio.CancelledError:
+            raise
+        except WebSocketDisconnect:
+            return
+        except Exception:
+            await websocket.close(code=1008)
+
+    async def wait(self) -> None:
+        if self._runner is not None:
+            await self._runner
+
+
+class Matchmaker:
+    """Pairs players into matches and manages the connection lifecycle."""
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._waiting: Optional[PlayerConnection] = None
+        self._active_matches: List[Match] = []
+        self._color_cycle = iter(PlayerColor)
+
+    def _next_color(self) -> PlayerColor:
+        try:
+            return next(self._color_cycle)
+        except StopIteration:
+            self._color_cycle = iter(PlayerColor)
+            return next(self._color_cycle)
+
+    async def register(self, name: str, websocket: WebSocket) -> tuple[PlayerConnection, Match]:
+        player = Player(id=str(uuid.uuid4()), name=name, color=self._next_color())
+        connection = PlayerConnection(websocket=websocket, player=player)
+        async with self._lock:
+            if self._waiting is None:
+                self._waiting = connection
+            else:
+                opponent = self._waiting
+                self._waiting = None
+                match = Match([opponent, connection])
+                opponent.match_ready.set_result(match)
+                connection.match_ready.set_result(match)
+                self._active_matches.append(match)
+                await match.start()
+        match = await connection.match_ready
+        return connection, match
+
+    async def remove_match(self, match: Match) -> None:
+        async with self._lock:
+            with contextlib.suppress(ValueError):
+                self._active_matches.remove(match)
+
+    async def handle_disconnect(self, connection: PlayerConnection) -> None:
+        async with self._lock:
+            if self._waiting is connection:
+                self._waiting = None

--- a/webapp/models.py
+++ b/webapp/models.py
@@ -1,0 +1,171 @@
+"""Data models for the Nova Frontier RTS simulation.
+
+The module defines serialisable dataclasses for all pieces of game state
+exchanged between the server and the browser client.  A lightweight schema
+allows us to document the wire protocol and keep the client entirely stateless;
+all authoritative logic lives on the server.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+from . import config
+
+Vector2 = Tuple[float, float]
+TileCoord = Tuple[int, int]
+
+
+class PlayerColor(str, Enum):
+    """Distinct colours assigned to players for rendering on the client."""
+
+    BLUE = "#3b82f6"
+    RED = "#ef4444"
+    GREEN = "#22c55e"
+    ORANGE = "#f97316"
+
+
+@dataclass(slots=True)
+class ResourceNode:
+    """A deposit that can be harvested by player harvesters."""
+
+    id: int
+    position: TileCoord
+    value_remaining: int = config.RESOURCE_NODE_VALUE
+
+    def take(self, amount: int) -> int:
+        """Remove up to ``amount`` credits and return the quantity gathered."""
+
+        gathered = min(amount, self.value_remaining)
+        self.value_remaining -= gathered
+        return gathered
+
+    def serialise(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "x": self.position[0],
+            "y": self.position[1],
+            "value": self.value_remaining,
+        }
+
+
+class UnitType(str, Enum):
+    """High level unit archetypes used by the simulation."""
+
+    HARVESTER = "harvester"
+    INFANTRY = "infantry"
+
+
+@dataclass(slots=True)
+class Unit:
+    """A mobile entity that can move, attack and harvest resources."""
+
+    id: int
+    owner_id: str
+    unit_type: UnitType
+    position: Vector2
+    target_position: Optional[Vector2] = None
+    target_unit: Optional[int] = None
+    health: int = config.UNIT_MAX_HEALTH
+    progress: float = 0.0
+    cooldown: float = 0.0
+    carrying: int = 0
+
+    def serialise(self) -> Dict[str, object]:
+        data = asdict(self)
+        data.update({
+            "x": self.position[0],
+            "y": self.position[1],
+            "target_position": self.target_position,
+        })
+        return data
+
+
+@dataclass(slots=True)
+class Base:
+    """Player headquarters. Destroying it ends the match."""
+
+    id: int
+    owner_id: str
+    position: TileCoord
+    health: int = config.BASE_MAX_HEALTH
+    cooldown: float = 0.0
+
+    def serialise(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "owner_id": self.owner_id,
+            "x": self.position[0],
+            "y": self.position[1],
+            "health": self.health,
+        }
+
+
+@dataclass(slots=True)
+class Player:
+    """Runtime representation of a connected player."""
+
+    id: str
+    name: str
+    color: PlayerColor
+    credits: int = config.STARTING_CREDITS
+    base: Optional[Base] = None
+    units: Dict[int, Unit] = field(default_factory=dict)
+
+    def serialise(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "color": self.color.value,
+            "credits": self.credits,
+            "base": self.base.serialise() if self.base else None,
+            "units": [unit.serialise() for unit in self.units.values()],
+        }
+
+
+@dataclass(slots=True)
+class GameState:
+    """All authoritative state for a single match."""
+
+    players: Dict[str, Player]
+    resource_nodes: Dict[int, ResourceNode]
+    time_elapsed: float = 0.0
+    winner: Optional[str] = None
+
+    def serialise(self) -> Dict[str, object]:
+        return {
+            "players": {pid: player.serialise() for pid, player in self.players.items()},
+            "resources": [node.serialise() for node in self.resource_nodes.values()],
+            "time": self.time_elapsed,
+            "winner": self.winner,
+            "config": {
+                "map": [config.MAP_WIDTH, config.MAP_HEIGHT],
+                "tile_size": config.TILE_SIZE,
+                "game_name": config.GAME_NAME,
+            },
+        }
+
+
+@dataclass(slots=True)
+class Command:
+    """A player issued command that will be executed on the next tick."""
+
+    player_id: str
+    action: str
+    payload: Dict[str, object]
+    issued_at: float
+
+
+@dataclass(slots=True)
+class MatchView:
+    """DTO used to push state updates to websocket clients."""
+
+    state: GameState
+    events: List[Dict[str, object]]
+
+    def serialise(self) -> Dict[str, object]:
+        return {
+            "state": self.state.serialise(),
+            "events": self.events,
+        }

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -1,0 +1,64 @@
+"""ASGI application exposing the Nova Frontier RTS experience."""
+from __future__ import annotations
+
+import pathlib
+from typing import Final
+
+from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from starlette.websockets import WebSocketState
+
+from . import config
+from .matchmaking import Match, Matchmaker, PlayerConnection
+
+APP_DIR: Final = pathlib.Path(__file__).resolve().parent
+FRONTEND_DIR: Final = APP_DIR.parent / "frontend"
+
+app = FastAPI(title=config.GAME_NAME, version="0.1.0")
+app.mount("/static", StaticFiles(directory=str(FRONTEND_DIR)), name="static")
+
+
+async def get_matchmaker() -> Matchmaker:
+    if not hasattr(app.state, "matchmaker"):
+        app.state.matchmaker = Matchmaker()
+    return app.state.matchmaker
+
+
+@app.get("/health")
+async def healthcheck() -> JSONResponse:
+    """Simple readiness probe for container orchestration."""
+
+    matchmaker = getattr(app.state, "matchmaker", None)
+    active_matches = len(matchmaker._active_matches) if matchmaker else 0
+    return JSONResponse({"status": "ok", "players_active": active_matches})
+
+
+@app.get("/")
+async def index() -> FileResponse:
+    """Serve the compiled front-end."""
+
+    index_path = FRONTEND_DIR / "index.html"
+    if not index_path.exists():
+        raise HTTPException(status_code=404, detail="Front-end not built")
+    return FileResponse(index_path)
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket, matchmaker: Matchmaker = Depends(get_matchmaker)) -> None:
+    name = websocket.query_params.get("name", "Commander")
+    await websocket.accept()
+    connection: PlayerConnection | None = None
+    match: Match | None = None
+    try:
+        connection, match = await matchmaker.register(name, websocket)
+        await match.wait()
+    except WebSocketDisconnect:
+        pass
+    finally:
+        if connection is not None:
+            await matchmaker.handle_disconnect(connection)
+        if match is not None:
+            await matchmaker.remove_match(match)
+        if websocket.application_state == WebSocketState.CONNECTED:
+            await websocket.close()


### PR DESCRIPTION
## Summary
- add a FastAPI-powered Nova Frontier server with deterministic RTS engine and websocket matchmaking
- build a browser canvas client with production controls and real-time rendering
- document the new workflow and add regression coverage for resource gathering and unit production

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf15e82aac832c950447e90391aa58