### PR TITLE
feat(web): render battlefield with three.js isometric view

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -1,5 +1,6 @@
+import * as THREE from "https://unpkg.com/three@0.156.0/build/three.module.js";
+
 const canvas = document.getElementById("battlefield");
-const ctx = canvas.getContext("2d");
 const connectBtn = document.getElementById("connect-btn");
 const roomInput = document.getElementById("room-input");
 const nameInput = document.getElementById("name-input");
@@ -20,11 +21,313 @@ let mapSize = [96, 64];
 let lastHover = null;
 
 const COLORS = {
-  grid: "#0f172a",
   enemy: "#ef4444",
   neutral: "#facc15",
   selection: "#38bdf8",
+  terrain: "#0b1120",
+  gridMain: "#334155",
+  gridSub: "#1e293b",
 };
+
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(window.devicePixelRatio);
+renderer.setSize(canvas.clientWidth || canvas.width, canvas.clientHeight || canvas.height, false);
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color("#020617");
+
+let camera = new THREE.OrthographicCamera(-10, 10, 10, -10, 0.1, 1000);
+camera.up.set(0, 1, 0);
+scene.add(new THREE.AmbientLight(0xffffff, 0.6));
+const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+dirLight.position.set(25, 50, 25);
+scene.add(dirLight);
+
+const terrainGroup = new THREE.Group();
+const resourceGroup = new THREE.Group();
+const buildingGroup = new THREE.Group();
+const unitGroup = new THREE.Group();
+const selectionGroup = new THREE.Group();
+scene.add(terrainGroup, resourceGroup, buildingGroup, unitGroup, selectionGroup);
+
+let groundMesh = null;
+let gridHelper = null;
+let environmentKey = "";
+
+const unitMeshes = new Map();
+const buildingMeshes = new Map();
+const resourceMeshes = new Map();
+const selectionMeshes = new Map();
+
+const raycaster = new THREE.Raycaster();
+const pointer = new THREE.Vector2();
+const groundPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+const intersectionPoint = new THREE.Vector3();
+
+setupEnvironment();
+updateCameraProjection(canvas.clientWidth || canvas.width, canvas.clientHeight || canvas.height);
+animate();
+
+function setupEnvironment() {
+  const key = `${mapSize[0]}x${mapSize[1]}`;
+  if (environmentKey === key) {
+    return;
+  }
+  environmentKey = key;
+  if (groundMesh) {
+    terrainGroup.remove(groundMesh);
+    groundMesh.geometry.dispose();
+    groundMesh.material.dispose();
+  }
+  if (gridHelper) {
+    terrainGroup.remove(gridHelper);
+  }
+  const [mapWidth, mapHeight] = mapSize;
+  const planeGeometry = new THREE.PlaneGeometry(
+    mapWidth,
+    mapHeight,
+    Math.max(1, Math.floor(mapWidth / 4)),
+    Math.max(1, Math.floor(mapHeight / 4))
+  );
+  const planeMaterial = new THREE.MeshPhongMaterial({ color: COLORS.terrain, shininess: 12 });
+  groundMesh = new THREE.Mesh(planeGeometry, planeMaterial);
+  groundMesh.rotation.x = -Math.PI / 2;
+  terrainGroup.add(groundMesh);
+
+  const gridSize = Math.max(mapWidth, mapHeight);
+  const divisions = Math.max(1, Math.floor(gridSize / 4));
+  gridHelper = new THREE.GridHelper(gridSize, divisions, COLORS.gridMain, COLORS.gridSub);
+  gridHelper.position.y = 0.05;
+  const gridMaterials = Array.isArray(gridHelper.material)
+    ? gridHelper.material
+    : [gridHelper.material];
+  gridMaterials.forEach((material) => {
+    material.opacity = 0.3;
+    material.transparent = true;
+  });
+  terrainGroup.add(gridHelper);
+}
+
+function updateCameraProjection(width, height) {
+  if (!camera) {
+    camera = new THREE.OrthographicCamera(-10, 10, 10, -10, 0.1, 1000);
+  }
+  const safeWidth = width || canvas.width || 960;
+  const safeHeight = height || canvas.height || 640;
+  const aspect = safeWidth / safeHeight;
+  const [mapWidth, mapHeight] = mapSize;
+  const frustumSize = Math.max(mapWidth, mapHeight) * 1.4;
+
+  camera.left = (-frustumSize * aspect) / 2;
+  camera.right = (frustumSize * aspect) / 2;
+  camera.top = frustumSize / 2;
+  camera.bottom = -frustumSize / 2;
+  camera.near = 0.1;
+  camera.far = 1000;
+  const distance = Math.max(mapWidth, mapHeight) * 1.2;
+  camera.position.set(distance, distance, distance);
+  camera.lookAt(0, 0, 0);
+  camera.updateProjectionMatrix();
+}
+
+function resizeRenderer() {
+  const width = canvas.clientWidth || canvas.width;
+  const height = canvas.clientHeight || canvas.height;
+  if (!width || !height) {
+    return;
+  }
+  const needResize = canvas.width !== width || canvas.height !== height;
+  if (needResize) {
+    renderer.setSize(width, height, false);
+  }
+  updateCameraProjection(width, height);
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  resizeRenderer();
+  renderer.render(scene, camera);
+}
+
+function mapToWorld(x, y) {
+  const [mapWidth, mapHeight] = mapSize;
+  return {
+    x: x - mapWidth / 2,
+    z: y - mapHeight / 2,
+  };
+}
+
+function getMapCoordinates(event) {
+  const rect = canvas.getBoundingClientRect();
+  const width = rect.width;
+  const height = rect.height;
+  if (!width || !height) {
+    return null;
+  }
+  pointer.x = ((event.clientX - rect.left) / width) * 2 - 1;
+  pointer.y = -((event.clientY - rect.top) / height) * 2 + 1;
+  raycaster.setFromCamera(pointer, camera);
+  const hit = raycaster.ray.intersectPlane(groundPlane, intersectionPoint);
+  if (!hit) {
+    return null;
+  }
+  const [mapWidth, mapHeight] = mapSize;
+  const mapX = intersectionPoint.x + mapWidth / 2;
+  const mapY = intersectionPoint.z + mapHeight / 2;
+  return { x: mapX, y: mapY };
+}
+
+function clearDynamicMeshes() {
+  for (const mesh of unitMeshes.values()) {
+    unitGroup.remove(mesh);
+    mesh.geometry.dispose();
+    mesh.material.dispose();
+  }
+  for (const mesh of buildingMeshes.values()) {
+    buildingGroup.remove(mesh);
+    mesh.geometry.dispose();
+    mesh.material.dispose();
+  }
+  for (const mesh of resourceMeshes.values()) {
+    resourceGroup.remove(mesh);
+    mesh.geometry.dispose();
+    mesh.material.dispose();
+  }
+  for (const mesh of selectionMeshes.values()) {
+    selectionGroup.remove(mesh);
+    mesh.geometry.dispose();
+    mesh.material.dispose();
+  }
+  unitMeshes.clear();
+  buildingMeshes.clear();
+  resourceMeshes.clear();
+  selectionMeshes.clear();
+}
+
+function syncResources() {
+  if (!gameState) return;
+  const seen = new Set();
+  for (const resource of gameState.resources) {
+    let mesh = resourceMeshes.get(resource.id);
+    if (!mesh) {
+      const geometry = new THREE.CylinderGeometry(1.5, 1.5, 1.2, 20);
+      const material = new THREE.MeshPhongMaterial({ color: COLORS.neutral });
+      mesh = new THREE.Mesh(geometry, material);
+      resourceGroup.add(mesh);
+      resourceMeshes.set(resource.id, mesh);
+    }
+    const world = mapToWorld(resource.position[0], resource.position[1]);
+    mesh.position.set(world.x, 0.6, world.z);
+    mesh.userData = { id: resource.id, kind: "resource" };
+    seen.add(resource.id);
+  }
+  for (const [id, mesh] of resourceMeshes.entries()) {
+    if (!seen.has(id)) {
+      resourceGroup.remove(mesh);
+      mesh.geometry.dispose();
+      mesh.material.dispose();
+      resourceMeshes.delete(id);
+    }
+  }
+}
+
+function syncBuildings() {
+  if (!gameState) return;
+  const seen = new Set();
+  for (const building of gameState.buildings) {
+    let mesh = buildingMeshes.get(building.id);
+    if (!mesh) {
+      const geometry = new THREE.BoxGeometry(4, 3, 4);
+      const material = new THREE.MeshPhongMaterial({ color: getPlayerColor(building.owner) });
+      mesh = new THREE.Mesh(geometry, material);
+      buildingGroup.add(mesh);
+      buildingMeshes.set(building.id, mesh);
+      mesh.userData = { id: building.id, kind: "building", selectionRadius: 2.8 };
+    }
+    mesh.material.color.set(getPlayerColor(building.owner));
+    const world = mapToWorld(building.position[0], building.position[1]);
+    mesh.position.set(world.x, 1.5, world.z);
+    seen.add(building.id);
+  }
+  for (const [id, mesh] of buildingMeshes.entries()) {
+    if (!seen.has(id)) {
+      buildingGroup.remove(mesh);
+      mesh.geometry.dispose();
+      mesh.material.dispose();
+      buildingMeshes.delete(id);
+    }
+  }
+}
+
+function syncUnits() {
+  if (!gameState) return;
+  const seen = new Set();
+  for (const unit of gameState.units) {
+    let mesh = unitMeshes.get(unit.id);
+    if (!mesh) {
+      const radius = unit.type === "tank" ? 1.4 : 1;
+      const geometry = new THREE.CylinderGeometry(radius, radius, 1.2, 24);
+      const material = new THREE.MeshPhongMaterial({ color: getPlayerColor(unit.owner) });
+      mesh = new THREE.Mesh(geometry, material);
+      mesh.rotation.x = 0;
+      unitGroup.add(mesh);
+      unitMeshes.set(unit.id, mesh);
+      mesh.userData = { id: unit.id, kind: "unit", selectionRadius: radius * 1.2 };
+    }
+    mesh.material.color.set(getPlayerColor(unit.owner));
+    const world = mapToWorld(unit.position[0], unit.position[1]);
+    mesh.position.set(world.x, 0.6, world.z);
+    seen.add(unit.id);
+  }
+  for (const [id, mesh] of unitMeshes.entries()) {
+    if (!seen.has(id)) {
+      unitGroup.remove(mesh);
+      mesh.geometry.dispose();
+      mesh.material.dispose();
+      unitMeshes.delete(id);
+    }
+  }
+}
+
+function syncSelections() {
+  const desired = new Set();
+  selectedUnits.forEach((id) => desired.add(id));
+  if (selectedBuilding) {
+    desired.add(selectedBuilding);
+  }
+
+  for (const id of desired) {
+    let targetMesh = unitMeshes.get(id) || buildingMeshes.get(id);
+    if (!targetMesh) {
+      continue;
+    }
+    let ring = selectionMeshes.get(id);
+    const baseRadius = targetMesh.userData?.selectionRadius || 1.4;
+    if (!ring) {
+      const geometry = new THREE.RingGeometry(baseRadius * 0.9, baseRadius * 1.1, 32);
+      const material = new THREE.MeshBasicMaterial({
+        color: COLORS.selection,
+        transparent: true,
+        opacity: 0.85,
+        side: THREE.DoubleSide,
+      });
+      ring = new THREE.Mesh(geometry, material);
+      ring.rotation.x = -Math.PI / 2;
+      selectionGroup.add(ring);
+      selectionMeshes.set(id, ring);
+    }
+    ring.position.set(targetMesh.position.x, 0.05, targetMesh.position.z);
+  }
+
+  for (const [id, ring] of selectionMeshes.entries()) {
+    if (!desired.has(id)) {
+      selectionGroup.remove(ring);
+      ring.geometry.dispose();
+      ring.material.dispose();
+      selectionMeshes.delete(id);
+    }
+  }
+}
 
 connectBtn.addEventListener("click", () => {
   if (socket) {
@@ -59,9 +362,11 @@ canvas.addEventListener("mousedown", (event) => {
   if (!gameState) {
     return;
   }
-  const rect = canvas.getBoundingClientRect();
-  const x = ((event.clientX - rect.left) / rect.width) * mapSize[0];
-  const y = ((event.clientY - rect.top) / rect.height) * mapSize[1];
+  const coords = getMapCoordinates(event);
+  if (!coords) {
+    return;
+  }
+  const { x, y } = coords;
 
   if (event.button === 0) {
     handleSelection(x, y, event.shiftKey);
@@ -72,10 +377,13 @@ canvas.addEventListener("mousedown", (event) => {
 
 canvas.addEventListener("mousemove", (event) => {
   if (!gameState) return;
-  const rect = canvas.getBoundingClientRect();
-  const x = ((event.clientX - rect.left) / rect.width) * mapSize[0];
-  const y = ((event.clientY - rect.top) / rect.height) * mapSize[1];
-  const hoverInfo = pickEntity(x, y);
+  const coords = getMapCoordinates(event);
+  if (!coords) {
+    tooltip.style.opacity = 0;
+    lastHover = null;
+    return;
+  }
+  const hoverInfo = pickEntity(coords.x, coords.y);
   if (hoverInfo && hoverInfo.id !== lastHover) {
     tooltip.textContent = hoverInfo.label;
     tooltip.style.opacity = 1;
@@ -132,6 +440,11 @@ function openSocket(room, name) {
     playerId = null;
     selectedUnits.clear();
     selectedBuilding = null;
+    gameState = null;
+    tooltip.style.opacity = 0;
+    lastHover = null;
+    clearDynamicMeshes();
+    draw();
   });
 }
 
@@ -147,6 +460,7 @@ function handleSelection(x, y, additive) {
     selectedBuilding = null;
   }
   if (!picked) {
+    draw();
     return;
   }
   if (picked.owner === playerId && picked.kind === "unit") {
@@ -158,6 +472,7 @@ function handleSelection(x, y, additive) {
   } else if (picked.owner === playerId && picked.kind === "building") {
     selectedBuilding = picked.id;
   }
+  draw();
 }
 
 function handleCommand(x, y) {
@@ -238,73 +553,14 @@ function pickEntity(x, y) {
 
 function draw() {
   if (!gameState) {
-    ctx.fillStyle = "#111827";
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    clearDynamicMeshes();
     return;
   }
-  const [mapWidth, mapHeight] = mapSize;
-  const sx = canvas.width / mapWidth;
-  const sy = canvas.height / mapHeight;
-
-  ctx.fillStyle = "#020617";
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-  // Grid
-  ctx.strokeStyle = COLORS.grid;
-  ctx.lineWidth = 1;
-  for (let gx = 0; gx <= mapWidth; gx += 4) {
-    ctx.beginPath();
-    ctx.moveTo(gx * sx, 0);
-    ctx.lineTo(gx * sx, canvas.height);
-    ctx.stroke();
-  }
-  for (let gy = 0; gy <= mapHeight; gy += 4) {
-    ctx.beginPath();
-    ctx.moveTo(0, gy * sy);
-    ctx.lineTo(canvas.width, gy * sy);
-    ctx.stroke();
-  }
-
-  // Resources
-  for (const resource of gameState.resources) {
-    ctx.fillStyle = COLORS.neutral;
-    const [rx, ry] = resource.position;
-    ctx.beginPath();
-    ctx.arc(rx * sx, ry * sy, 6, 0, Math.PI * 2);
-    ctx.fill();
-  }
-
-  // Buildings
-  for (const building of gameState.buildings) {
-    const [bx, by] = building.position;
-    const color = getPlayerColor(building.owner);
-    const width = 12;
-    const height = 12;
-    ctx.fillStyle = color;
-    ctx.fillRect(bx * sx - width / 2, by * sy - height / 2, width, height);
-    if (selectedBuilding === building.id) {
-      ctx.strokeStyle = COLORS.selection;
-      ctx.lineWidth = 3;
-      ctx.strokeRect(bx * sx - width / 2 - 3, by * sy - height / 2 - 3, width + 6, height + 6);
-    }
-  }
-
-  // Units
-  for (const unit of gameState.units) {
-    const [ux, uy] = unit.position;
-    const radius = unit.type === "tank" ? 6 : 4;
-    ctx.fillStyle = getPlayerColor(unit.owner);
-    ctx.beginPath();
-    ctx.arc(ux * sx, uy * sy, radius, 0, Math.PI * 2);
-    ctx.fill();
-    if (selectedUnits.has(unit.id)) {
-      ctx.strokeStyle = COLORS.selection;
-      ctx.lineWidth = 2;
-      ctx.beginPath();
-      ctx.arc(ux * sx, uy * sy, radius + 3, 0, Math.PI * 2);
-      ctx.stroke();
-    }
-  }
+  setupEnvironment();
+  syncResources();
+  syncBuildings();
+  syncUnits();
+  syncSelections();
 }
 
 function getPlayerColor(owner) {


### PR DESCRIPTION
## Summary
- replace the 2D canvas renderer with a Three.js scene that provides an isometric orthographic camera
- render terrain, resources, buildings, and units as 3D meshes with selection indicators synchronized to game state
- update input handling to use raycasting for selection, tooltips, and command issuing on the 3D battlefield

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf218ab5c0832c843d4c5a0b93ca3f