### PR TITLE
Add Red Alert 2 inspired units and buildings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,46 +11,108 @@ STARTING_CREDITS = 1000
 HARVEST_RATE_PER_SECOND = 20
 HARVEST_NODE_CAPACITY = 5000
 
-# Unit statistics keyed by unit type.
+# Unit statistics keyed by unit type. Stats are loosely inspired by
+# Red Alert 2 unit archetypes to provide a varied roster.
 UNIT_STATS = {
-    "harvester": {
-        "max_hp": 120,
-        "speed": 6.0,
+    "ore_miner": {
+        "max_hp": 250,
+        "speed": 5.0,
         "attack_damage": 0,
         "attack_range": 0,
         "attack_cooldown": 1.0,
-        "cost": 300,
-        "build_time": 8.0,
+        "cost": 600,
+        "build_time": 9.0,
     },
-    "soldier": {
-        "max_hp": 80,
-        "speed": 10.0,
-        "attack_damage": 8,
+    "conscript": {
+        "max_hp": 90,
+        "speed": 9.5,
+        "attack_damage": 9,
         "attack_range": 6.0,
         "attack_cooldown": 0.8,
-        "cost": 150,
-        "build_time": 4.0,
+        "cost": 100,
+        "build_time": 3.5,
     },
-    "tank": {
-        "max_hp": 300,
+    "gi": {
+        "max_hp": 110,
+        "speed": 8.5,
+        "attack_damage": 14,
+        "attack_range": 7.0,
+        "attack_cooldown": 1.0,
+        "cost": 200,
+        "build_time": 4.5,
+    },
+    "tesla_trooper": {
+        "max_hp": 160,
         "speed": 7.0,
-        "attack_damage": 25,
-        "attack_range": 8.0,
+        "attack_damage": 28,
+        "attack_range": 6.5,
+        "attack_cooldown": 1.4,
+        "cost": 400,
+        "build_time": 6.5,
+    },
+    "rhino_tank": {
+        "max_hp": 420,
+        "speed": 6.5,
+        "attack_damage": 36,
+        "attack_range": 7.0,
         "attack_cooldown": 1.6,
+        "cost": 700,
+        "build_time": 11.0,
+    },
+    "grizzly_tank": {
+        "max_hp": 360,
+        "speed": 7.5,
+        "attack_damage": 30,
+        "attack_range": 7.5,
+        "attack_cooldown": 1.5,
         "cost": 650,
-        "build_time": 12.0,
+        "build_time": 10.0,
+    },
+    "prism_tank": {
+        "max_hp": 320,
+        "speed": 7.2,
+        "attack_damage": 55,
+        "attack_range": 9.5,
+        "attack_cooldown": 2.0,
+        "cost": 1200,
+        "build_time": 16.0,
+    },
+    "rocketeer": {
+        "max_hp": 140,
+        "speed": 11.0,
+        "attack_damage": 18,
+        "attack_range": 8.0,
+        "attack_cooldown": 1.2,
+        "cost": 500,
+        "build_time": 8.0,
     },
 }
 
 # Building statistics keyed by building type.
 BUILDING_STATS = {
-    "hq": {
-        "max_hp": 3000,
-        "buildable_units": ["harvester", "soldier"],
+    "construction_yard": {
+        "max_hp": 3200,
+        "buildable_units": ["conscript", "ore_miner"],
     },
-    "factory": {
+    "ore_refinery": {
+        "max_hp": 2100,
+        "buildable_units": ["ore_miner"],
+    },
+    "power_plant": {
+        "max_hp": 1500,
+        "buildable_units": [],
+    },
+    "barracks": {
+        "max_hp": 1800,
+        "buildable_units": ["conscript", "gi", "tesla_trooper", "rocketeer"],
+    },
+    "war_factory": {
+        "max_hp": 2300,
+        "buildable_units": ["ore_miner", "rhino_tank", "grizzly_tank"],
+    },
+    "battle_lab": {
         "max_hp": 2000,
-        "buildable_units": ["soldier", "tank"],
+        "buildable_units": ["prism_tank", "tesla_trooper", "rocketeer"],
     },
 }
 

--- a/app/game.py
+++ b/app/game.py
@@ -355,22 +355,51 @@ class RTSGame:
             )
 
     def _spawn_starting_base(self, player: PlayerState, spawn: Tuple[float, float]) -> None:
-        hq = self._spawn_building(player, "hq", Vector2(spawn[0], spawn[1]))
-        factory_offset = Vector2(spawn[0] + 4, spawn[1] + 4)
-        factory = self._spawn_building(player, "factory", factory_offset)
-        player.buildings[hq.id] = hq
-        player.buildings[factory.id] = factory
-        self.buildings[hq.id] = hq
-        self.buildings[factory.id] = factory
+        yard = self._spawn_building(player, "construction_yard", Vector2(spawn[0], spawn[1]))
+        refinery = self._spawn_building(
+            player, "ore_refinery", Vector2(spawn[0] + 5, spawn[1] + 3)
+        )
+        power = self._spawn_building(
+            player, "power_plant", Vector2(spawn[0] - 6, spawn[1] + 2)
+        )
+        barracks = self._spawn_building(
+            player, "barracks", Vector2(spawn[0] + 3, spawn[1] - 5)
+        )
+        war_factory = self._spawn_building(
+            player, "war_factory", Vector2(spawn[0] + 9, spawn[1] + 6)
+        )
+        player.buildings[yard.id] = yard
+        player.buildings[refinery.id] = refinery
+        player.buildings[power.id] = power
+        player.buildings[barracks.id] = barracks
+        player.buildings[war_factory.id] = war_factory
+        self.buildings[yard.id] = yard
+        self.buildings[refinery.id] = refinery
+        self.buildings[power.id] = power
+        self.buildings[barracks.id] = barracks
+        self.buildings[war_factory.id] = war_factory
 
-        # Initial army
-        for _ in range(2):
-            soldier = self._spawn_unit(player, "soldier", near=factory.position)
-            player.units[soldier.id] = soldier
-            self.units[soldier.id] = soldier
-        harvester = self._spawn_unit(player, "harvester", near=hq.position)
-        player.units[harvester.id] = harvester
-        self.units[harvester.id] = harvester
+        # Starting forces: basic infantry squad, one advanced infantry and armor, plus an ore miner
+        for offset in (-1.5, 0.0, 1.5):
+            conscript = self._spawn_unit(
+                player,
+                "conscript",
+                near=Vector2(barracks.position.x + offset, barracks.position.y + 1.0),
+            )
+            player.units[conscript.id] = conscript
+            self.units[conscript.id] = conscript
+
+        gi = self._spawn_unit(player, "gi", near=barracks.position)
+        player.units[gi.id] = gi
+        self.units[gi.id] = gi
+
+        rhino = self._spawn_unit(player, "rhino_tank", near=war_factory.position)
+        player.units[rhino.id] = rhino
+        self.units[rhino.id] = rhino
+
+        miner = self._spawn_unit(player, "ore_miner", near=refinery.position)
+        player.units[miner.id] = miner
+        self.units[miner.id] = miner
 
     def _spawn_building(
         self, player: PlayerState, kind: str, position: Vector2
@@ -403,7 +432,7 @@ class RTSGame:
             attack_damage=stats["attack_damage"],
             attack_range=stats["attack_range"],
             attack_cooldown=stats["attack_cooldown"],
-            role="harvester" if unit_type == "harvester" else "combat",
+            role="harvester" if unit_type == "ore_miner" else "combat",
         )
         return unit
 

--- a/tests/test_gameplay.py
+++ b/tests/test_gameplay.py
@@ -22,12 +22,21 @@ def test_player_join_spawns_base() -> None:
 def test_production_queue_creates_units() -> None:
     game = RTSGame("room")
     player = game.add_player("p1", "Builder")
-    hq = next(iter(player.buildings.values()))
+    barracks = next(
+        building
+        for building in player.buildings.values()
+        if "conscript" in building.buildable_units
+    )
     game.enqueue_command(
-        "p1", {"action": "build_unit", "building_id": hq.id, "unit_type": "soldier"}
+        "p1",
+        {
+            "action": "build_unit",
+            "building_id": barracks.id,
+            "unit_type": "conscript",
+        },
     )
     run_updates(game, seconds=6.0)
-    assert any(unit.kind == "soldier" for unit in player.units.values())
+    assert any(unit.kind == "conscript" for unit in player.units.values())
     assert player.credits < config.STARTING_CREDITS
 
 
@@ -35,8 +44,8 @@ def test_combat_units_destroy_targets() -> None:
     game = RTSGame("room")
     p1 = game.add_player("p1", "Alpha")
     p2 = game.add_player("p2", "Bravo")
-    attacker = next(iter(p1.units.values()))
-    defender = next(iter(p2.units.values()))
+    attacker = next(unit for unit in p1.units.values() if unit.role == "combat")
+    defender = next(unit for unit in p2.units.values() if unit.role == "combat")
     attacker.position = Vector2(20, 20)
     defender.position = Vector2(21, 20)
     game.enqueue_command(


### PR DESCRIPTION
## Summary
- expand the unit roster with Red Alert 2 inspired infantry, vehicles, and ore miners including updated stats and build costs
- seed starting bases with themed structures such as construction yards, ore refineries, barracks, and war factories while spawning a mixed army
- adapt production and combat tests to the new roster while keeping harvesting behaviour intact

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf264c308c832c8e9f517a3b1fc46f