### PR TITLE
Add Red Alert 2 units, buildings, and UI enhancements

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -7,50 +7,96 @@ STATE_BROADCAST_RATE = 10  # snapshots per second
 MAX_PLAYERS_PER_ROOM = 4
 
 # Economic tuning
-STARTING_CREDITS = 1000
+STARTING_CREDITS = 2500
 HARVEST_RATE_PER_SECOND = 20
 HARVEST_NODE_CAPACITY = 5000
 
 # Unit statistics keyed by unit type.
 UNIT_STATS = {
-    "harvester": {
-        "max_hp": 120,
-        "speed": 6.0,
+    "ore_miner": {
+        "max_hp": 420,
+        "speed": 5.2,
         "attack_damage": 0,
         "attack_range": 0,
         "attack_cooldown": 1.0,
-        "cost": 300,
-        "build_time": 8.0,
-    },
-    "soldier": {
-        "max_hp": 80,
-        "speed": 10.0,
-        "attack_damage": 8,
-        "attack_range": 6.0,
-        "attack_cooldown": 0.8,
-        "cost": 150,
-        "build_time": 4.0,
-    },
-    "tank": {
-        "max_hp": 300,
-        "speed": 7.0,
-        "attack_damage": 25,
-        "attack_range": 8.0,
-        "attack_cooldown": 1.6,
-        "cost": 650,
+        "cost": 1200,
         "build_time": 12.0,
+        "role": "harvester",
+    },
+    "conscript": {
+        "max_hp": 85,
+        "speed": 9.0,
+        "attack_damage": 7,
+        "attack_range": 5.0,
+        "attack_cooldown": 0.7,
+        "cost": 100,
+        "build_time": 3.5,
+        "role": "combat",
+    },
+    "gi": {
+        "max_hp": 110,
+        "speed": 7.5,
+        "attack_damage": 10,
+        "attack_range": 6.5,
+        "attack_cooldown": 0.85,
+        "cost": 200,
+        "build_time": 4.5,
+        "role": "combat",
+    },
+    "grizzly_tank": {
+        "max_hp": 420,
+        "speed": 8.0,
+        "attack_damage": 24,
+        "attack_range": 7.0,
+        "attack_cooldown": 1.3,
+        "cost": 700,
+        "build_time": 9.0,
+        "role": "combat",
+    },
+    "prism_tank": {
+        "max_hp": 320,
+        "speed": 6.5,
+        "attack_damage": 45,
+        "attack_range": 12.0,
+        "attack_cooldown": 3.5,
+        "cost": 1200,
+        "build_time": 16.0,
+        "role": "combat",
+    },
+    "mirage_tank": {
+        "max_hp": 360,
+        "speed": 7.0,
+        "attack_damage": 32,
+        "attack_range": 9.0,
+        "attack_cooldown": 2.2,
+        "cost": 1000,
+        "build_time": 14.0,
+        "role": "combat",
     },
 }
 
 # Building statistics keyed by building type.
 BUILDING_STATS = {
-    "hq": {
-        "max_hp": 3000,
-        "buildable_units": ["harvester", "soldier"],
+    "construction_yard": {
+        "max_hp": 3500,
+        "buildable_units": ["ore_miner"],
     },
-    "factory": {
-        "max_hp": 2000,
-        "buildable_units": ["soldier", "tank"],
+    "ore_refinery": {
+        "max_hp": 2500,
+        "buildable_units": ["ore_miner"],
+    },
+    "barracks": {
+        "max_hp": 1800,
+        "buildable_units": ["conscript", "gi"],
+    },
+    "war_factory": {
+        "max_hp": 2600,
+        "buildable_units": [
+            "ore_miner",
+            "grizzly_tank",
+            "prism_tank",
+            "mirage_tank",
+        ],
     },
 }
 

--- a/tests/test_gameplay.py
+++ b/tests/test_gameplay.py
@@ -22,12 +22,19 @@ def test_player_join_spawns_base() -> None:
 def test_production_queue_creates_units() -> None:
     game = RTSGame("room")
     player = game.add_player("p1", "Builder")
-    hq = next(iter(player.buildings.values()))
+    barracks = next(
+        building for building in player.buildings.values() if building.kind == "barracks"
+    )
     game.enqueue_command(
-        "p1", {"action": "build_unit", "building_id": hq.id, "unit_type": "soldier"}
+        "p1",
+        {
+            "action": "build_unit",
+            "building_id": barracks.id,
+            "unit_type": "conscript",
+        },
     )
     run_updates(game, seconds=6.0)
-    assert any(unit.kind == "soldier" for unit in player.units.values())
+    assert any(unit.kind == "conscript" for unit in player.units.values())
     assert player.credits < config.STARTING_CREDITS
 
 
@@ -35,8 +42,8 @@ def test_combat_units_destroy_targets() -> None:
     game = RTSGame("room")
     p1 = game.add_player("p1", "Alpha")
     p2 = game.add_player("p2", "Bravo")
-    attacker = next(iter(p1.units.values()))
-    defender = next(iter(p2.units.values()))
+    attacker = next(unit for unit in p1.units.values() if unit.role == "combat")
+    defender = next(unit for unit in p2.units.values() if unit.role == "combat")
     attacker.position = Vector2(20, 20)
     defender.position = Vector2(21, 20)
     game.enqueue_command(

--- a/web/index.html
+++ b/web/index.html
@@ -32,13 +32,10 @@
       <aside class="sidebar">
         <section class="panel">
           <h2>Production</h2>
-          <div class="button-grid">
-            <button data-unit="harvester">Train Harvester</button>
-            <button data-unit="soldier">Train Soldier</button>
-            <button data-unit="tank">Construct Tank</button>
-          </div>
-          <p class="hint">
-            Select your headquarters or factory to use production commands.
+          <div id="production-buttons" class="button-grid"></div>
+          <div id="production-queue" class="queue"></div>
+          <p id="production-hint" class="hint">
+            Select one of your structures to view available unit training options.
           </p>
         </section>
         <section class="panel">

--- a/web/styles.css
+++ b/web/styles.css
@@ -152,6 +152,47 @@ canvas#battlefield {
   border-color: var(--accent);
 }
 
+.button-grid button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  border-color: #1f2937;
+  box-shadow: none;
+}
+
+.button-grid button strong {
+  display: block;
+  font-size: 0.95rem;
+}
+
+.button-grid button .meta {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.button-grid button .desc {
+  display: block;
+  margin-top: 0.35rem;
+  font-size: 0.72rem;
+  line-height: 1.3;
+  color: var(--muted);
+}
+
+.queue {
+  margin-top: 0.75rem;
+  padding: 0.5rem;
+  background: #0f172a;
+  border-radius: 0.4rem;
+  border: 1px solid #1f2937;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.queue strong {
+  color: var(--text);
+}
+
 .panel ul {
   padding-left: 1.2rem;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- Introduce a Red Alert 2-inspired roster of buildings and combat/economic units with updated spawn logic and events
- Expose buildable unit data in snapshots and refresh gameplay tests around the new roster
- Rework the browser HUD to render dynamic production buttons, queue details, and themed sizing for units and structures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf264c308c832c8e9f517a3b1fc46f