### PR TITLE
Add Red Alert inspired units, structures, and production UI

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,46 +11,121 @@ STARTING_CREDITS = 1000
 HARVEST_RATE_PER_SECOND = 20
 HARVEST_NODE_CAPACITY = 5000
 
-# Unit statistics keyed by unit type.
+# Unit statistics keyed by unit type. Inspired by classic Red Alert 2 units.
 UNIT_STATS = {
-    "harvester": {
-        "max_hp": 120,
-        "speed": 6.0,
+    "ore_miner": {
+        "max_hp": 320,
+        "speed": 5.2,
         "attack_damage": 0,
         "attack_range": 0,
         "attack_cooldown": 1.0,
-        "cost": 300,
-        "build_time": 8.0,
+        "cost": 800,
+        "build_time": 12.0,
+        "role": "harvester",
     },
-    "soldier": {
-        "max_hp": 80,
-        "speed": 10.0,
-        "attack_damage": 8,
+    "conscript": {
+        "max_hp": 90,
+        "speed": 9.5,
+        "attack_damage": 9,
         "attack_range": 6.0,
         "attack_cooldown": 0.8,
-        "cost": 150,
-        "build_time": 4.0,
+        "cost": 100,
+        "build_time": 3.0,
     },
-    "tank": {
-        "max_hp": 300,
-        "speed": 7.0,
-        "attack_damage": 25,
+    "gi": {
+        "max_hp": 140,
+        "speed": 7.5,
+        "attack_damage": 16,
+        "attack_range": 7.0,
+        "attack_cooldown": 1.0,
+        "cost": 250,
+        "build_time": 5.0,
+    },
+    "engineer": {
+        "max_hp": 60,
+        "speed": 8.5,
+        "attack_damage": 0,
+        "attack_range": 0,
+        "attack_cooldown": 1.5,
+        "cost": 500,
+        "build_time": 6.0,
+    },
+    "rocketeer": {
+        "max_hp": 110,
+        "speed": 11.0,
+        "attack_damage": 14,
+        "attack_range": 8.5,
+        "attack_cooldown": 0.9,
+        "cost": 600,
+        "build_time": 8.0,
+    },
+    "grizzly_tank": {
+        "max_hp": 420,
+        "speed": 6.5,
+        "attack_damage": 32,
         "attack_range": 8.0,
-        "attack_cooldown": 1.6,
+        "attack_cooldown": 1.4,
+        "cost": 700,
+        "build_time": 10.0,
+    },
+    "prism_tank": {
+        "max_hp": 360,
+        "speed": 6.8,
+        "attack_damage": 48,
+        "attack_range": 11.0,
+        "attack_cooldown": 2.0,
+        "cost": 1200,
+        "build_time": 16.0,
+    },
+    "ifv": {
+        "max_hp": 280,
+        "speed": 8.0,
+        "attack_damage": 20,
+        "attack_range": 9.0,
+        "attack_cooldown": 1.2,
         "cost": 650,
-        "build_time": 12.0,
+        "build_time": 9.0,
+    },
+    "mirage_tank": {
+        "max_hp": 380,
+        "speed": 7.2,
+        "attack_damage": 42,
+        "attack_range": 10.0,
+        "attack_cooldown": 1.8,
+        "cost": 1000,
+        "build_time": 14.0,
     },
 }
 
 # Building statistics keyed by building type.
 BUILDING_STATS = {
-    "hq": {
-        "max_hp": 3000,
-        "buildable_units": ["harvester", "soldier"],
+    "construction_yard": {
+        "max_hp": 4000,
+        "buildable_units": ["engineer"],
     },
-    "factory": {
-        "max_hp": 2000,
-        "buildable_units": ["soldier", "tank"],
+    "power_plant": {
+        "max_hp": 1500,
+        "buildable_units": [],
+    },
+    "ore_refinery": {
+        "max_hp": 2200,
+        "buildable_units": ["ore_miner"],
+    },
+    "barracks": {
+        "max_hp": 1800,
+        "buildable_units": ["conscript", "gi", "engineer", "rocketeer"],
+    },
+    "war_factory": {
+        "max_hp": 2500,
+        "buildable_units": ["grizzly_tank", "ifv", "mirage_tank", "prism_tank"],
+    },
+    "airforce_command": {
+        "max_hp": 2100,
+        "buildable_units": ["rocketeer"],
+    },
+    "prism_tower": {
+        "max_hp": 1600,
+        "buildable_units": [],
     },
 }
 

--- a/tests/test_gameplay.py
+++ b/tests/test_gameplay.py
@@ -22,12 +22,17 @@ def test_player_join_spawns_base() -> None:
 def test_production_queue_creates_units() -> None:
     game = RTSGame("room")
     player = game.add_player("p1", "Builder")
-    hq = next(iter(player.buildings.values()))
+    barracks = next(b for b in player.buildings.values() if b.kind == "barracks")
     game.enqueue_command(
-        "p1", {"action": "build_unit", "building_id": hq.id, "unit_type": "soldier"}
+        "p1",
+        {
+            "action": "build_unit",
+            "building_id": barracks.id,
+            "unit_type": "conscript",
+        },
     )
     run_updates(game, seconds=6.0)
-    assert any(unit.kind == "soldier" for unit in player.units.values())
+    assert any(unit.kind == "conscript" for unit in player.units.values())
     assert player.credits < config.STARTING_CREDITS
 
 
@@ -35,8 +40,8 @@ def test_combat_units_destroy_targets() -> None:
     game = RTSGame("room")
     p1 = game.add_player("p1", "Alpha")
     p2 = game.add_player("p2", "Bravo")
-    attacker = next(iter(p1.units.values()))
-    defender = next(iter(p2.units.values()))
+    attacker = next(unit for unit in p1.units.values() if unit.role == "combat")
+    defender = next(unit for unit in p2.units.values() if unit.role == "combat")
     attacker.position = Vector2(20, 20)
     defender.position = Vector2(21, 20)
     game.enqueue_command(

--- a/web/index.html
+++ b/web/index.html
@@ -32,13 +32,10 @@
       <aside class="sidebar">
         <section class="panel">
           <h2>Production</h2>
-          <div class="button-grid">
-            <button data-unit="harvester">Train Harvester</button>
-            <button data-unit="soldier">Train Soldier</button>
-            <button data-unit="tank">Construct Tank</button>
-          </div>
-          <p class="hint">
-            Select your headquarters or factory to use production commands.
+          <div id="production-buttons" class="button-grid"></div>
+          <p class="hint" id="production-hint">
+            Select a production structure (Barracks, War Factory, Refinery, etc.) to queue
+            Red Alert inspired units.
           </p>
         </section>
         <section class="panel">


### PR DESCRIPTION
## Summary
- expand unit and building stats to include a suite of Red Alert 2-inspired forces and starting base layout
- update the client to surface building-specific production buttons with improved visuals for new unit and structure types
- adjust gameplay tests to exercise the new units and harvesting roles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf264c308c832c8e9f517a3b1fc46f