### PR TITLE
Expand map and spread out starting base

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 """Configuration constants for the RTS web application."""
 
-MAP_WIDTH = 96
-MAP_HEIGHT = 64
+MAP_WIDTH = 160
+MAP_HEIGHT = 120
 TICK_RATE = 10  # ticks per second
 STATE_BROADCAST_RATE = 10  # snapshots per second
 MAX_PLAYERS_PER_ROOM = 4
@@ -131,15 +131,15 @@ BUILDING_STATS = {
 
 # Spawn positions arranged clockwise starting from bottom-left.
 SPAWN_POSITIONS = [
-    (10.0, 10.0),
-    (MAP_WIDTH - 10.0, MAP_HEIGHT - 10.0),
-    (10.0, MAP_HEIGHT - 10.0),
-    (MAP_WIDTH - 10.0, 10.0),
+    (36.0, 36.0),
+    (MAP_WIDTH - 36.0, MAP_HEIGHT - 36.0),
+    (36.0, MAP_HEIGHT - 36.0),
+    (MAP_WIDTH - 36.0, 36.0),
 ]
 
 RESOURCE_NODE_POSITIONS = [
-    (MAP_WIDTH / 2, MAP_HEIGHT / 2),
-    (MAP_WIDTH / 2 + 15, MAP_HEIGHT / 2 - 12),
-    (MAP_WIDTH / 2 - 20, MAP_HEIGHT / 2 + 16),
-    (MAP_WIDTH / 2 + 5, MAP_HEIGHT / 2 + 18),
+    (MAP_WIDTH / 2 - 20, MAP_HEIGHT / 2 - 10),
+    (MAP_WIDTH / 2 + 26, MAP_HEIGHT / 2 + 18),
+    (MAP_WIDTH / 2 - 34, MAP_HEIGHT / 2 + 26),
+    (MAP_WIDTH / 2 + 14, MAP_HEIGHT / 2 - 30),
 ]

--- a/app/game.py
+++ b/app/game.py
@@ -365,12 +365,12 @@ class RTSGame:
         base_center = Vector2(spawn[0], spawn[1])
         layout = [
             ("construction_yard", base_center.copy()),
-            ("power_plant", Vector2(base_center.x + 6, base_center.y - 4)),
-            ("ore_refinery", Vector2(base_center.x - 6, base_center.y + 4)),
-            ("barracks", Vector2(base_center.x + 8, base_center.y + 6)),
-            ("war_factory", Vector2(base_center.x + 14, base_center.y + 2)),
-            ("airforce_command", Vector2(base_center.x - 4, base_center.y + 10)),
-            ("prism_tower", Vector2(base_center.x + 4, base_center.y + 12)),
+            ("power_plant", Vector2(base_center.x + 22, base_center.y - 18)),
+            ("ore_refinery", Vector2(base_center.x - 28, base_center.y + 14)),
+            ("barracks", Vector2(base_center.x + 24, base_center.y + 18)),
+            ("war_factory", Vector2(base_center.x - 26, base_center.y - 16)),
+            ("airforce_command", Vector2(base_center.x, base_center.y + 28)),
+            ("prism_tower", Vector2(base_center.x + 30, base_center.y + 2)),
         ]
 
         buildings_by_kind: Dict[str, Building] = {}

--- a/web/main.js
+++ b/web/main.js
@@ -34,7 +34,7 @@ let playerColor = "#ffffff";
 let gameState = null;
 let selectedUnits = new Set();
 let selectedBuilding = null; // { id: string, type: string } | null
-let mapSize = [96, 64];
+let mapSize = [160, 120];
 let lastHover = null;
 
 let ground = null;


### PR DESCRIPTION
## Summary
- enlarge the default battlefield dimensions and reposition resource nodes and spawns
- space out the starting base layout so production structures are easier to click
- sync the client default map size with the server configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf2a12197c832ca2b46eaa2212fb2d