### PR TITLE
Expand battlefield layout and restore unit production

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 """Configuration constants for the RTS web application."""
 
-MAP_WIDTH = 96
-MAP_HEIGHT = 64
+MAP_WIDTH = 160
+MAP_HEIGHT = 120
 TICK_RATE = 10  # ticks per second
 STATE_BROADCAST_RATE = 10  # snapshots per second
 MAX_PLAYERS_PER_ROOM = 4
@@ -131,15 +131,15 @@ BUILDING_STATS = {
 
 # Spawn positions arranged clockwise starting from bottom-left.
 SPAWN_POSITIONS = [
-    (10.0, 10.0),
-    (MAP_WIDTH - 10.0, MAP_HEIGHT - 10.0),
-    (10.0, MAP_HEIGHT - 10.0),
-    (MAP_WIDTH - 10.0, 10.0),
+    (32.0, 32.0),
+    (MAP_WIDTH - 32.0, MAP_HEIGHT - 32.0),
+    (32.0, MAP_HEIGHT - 32.0),
+    (MAP_WIDTH - 32.0, 32.0),
 ]
 
 RESOURCE_NODE_POSITIONS = [
     (MAP_WIDTH / 2, MAP_HEIGHT / 2),
-    (MAP_WIDTH / 2 + 15, MAP_HEIGHT / 2 - 12),
-    (MAP_WIDTH / 2 - 20, MAP_HEIGHT / 2 + 16),
-    (MAP_WIDTH / 2 + 5, MAP_HEIGHT / 2 + 18),
+    (MAP_WIDTH / 2 + 24, MAP_HEIGHT / 2 - 18),
+    (MAP_WIDTH / 2 - 28, MAP_HEIGHT / 2 + 24),
+    (MAP_WIDTH / 2 + 10, MAP_HEIGHT / 2 + 32),
 ]

--- a/app/game.py
+++ b/app/game.py
@@ -245,8 +245,9 @@ class RTSGame:
             unit.position.move_towards(target.position, unit.speed * dt)
             return
         if unit.current_cooldown > 0:
-            unit.current_cooldown -= dt
-            return
+            unit.current_cooldown = max(unit.current_cooldown - dt, 0.0)
+            if unit.current_cooldown > 0:
+                return
         target.take_damage(unit.attack_damage)
         unit.current_cooldown = unit.attack_cooldown
         if not target.is_alive():
@@ -365,12 +366,12 @@ class RTSGame:
         base_center = Vector2(spawn[0], spawn[1])
         layout = [
             ("construction_yard", base_center.copy()),
-            ("power_plant", Vector2(base_center.x + 6, base_center.y - 4)),
-            ("ore_refinery", Vector2(base_center.x - 6, base_center.y + 4)),
-            ("barracks", Vector2(base_center.x + 8, base_center.y + 6)),
-            ("war_factory", Vector2(base_center.x + 14, base_center.y + 2)),
-            ("airforce_command", Vector2(base_center.x - 4, base_center.y + 10)),
-            ("prism_tower", Vector2(base_center.x + 4, base_center.y + 12)),
+            ("power_plant", Vector2(base_center.x + 14, base_center.y - 10)),
+            ("ore_refinery", Vector2(base_center.x - 16, base_center.y + 12)),
+            ("barracks", Vector2(base_center.x + 6, base_center.y + 18)),
+            ("war_factory", Vector2(base_center.x + 20, base_center.y + 6)),
+            ("airforce_command", Vector2(base_center.x - 8, base_center.y + 24)),
+            ("prism_tower", Vector2(base_center.x + 10, base_center.y + 28)),
         ]
 
         buildings_by_kind: Dict[str, Building] = {}

--- a/web/main.js
+++ b/web/main.js
@@ -34,7 +34,7 @@ let playerColor = "#ffffff";
 let gameState = null;
 let selectedUnits = new Set();
 let selectedBuilding = null; // { id: string, type: string } | null
-let mapSize = [96, 64];
+let mapSize = [160, 120];
 let lastHover = null;
 
 let ground = null;


### PR DESCRIPTION
## Summary
- enlarge the default map and reposition spawn/resource coordinates to create more breathing room
- spread out the initial base layout so production structures are easier to select
- tighten the combat cooldown logic so infantry and vehicles fire at the expected cadence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf2a12197c832ca2b46eaa2212fb2d