### PR TITLE
Expand map and improve production controls

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,7 +1,7 @@
 """Configuration constants for the RTS web application."""
 
-MAP_WIDTH = 96
-MAP_HEIGHT = 64
+MAP_WIDTH = 160
+MAP_HEIGHT = 120
 TICK_RATE = 10  # ticks per second
 STATE_BROADCAST_RATE = 10  # snapshots per second
 MAX_PLAYERS_PER_ROOM = 4
@@ -131,15 +131,15 @@ BUILDING_STATS = {
 
 # Spawn positions arranged clockwise starting from bottom-left.
 SPAWN_POSITIONS = [
-    (10.0, 10.0),
-    (MAP_WIDTH - 10.0, MAP_HEIGHT - 10.0),
-    (10.0, MAP_HEIGHT - 10.0),
-    (MAP_WIDTH - 10.0, 10.0),
+    (20.0, 20.0),
+    (MAP_WIDTH - 20.0, MAP_HEIGHT - 20.0),
+    (20.0, MAP_HEIGHT - 20.0),
+    (MAP_WIDTH - 20.0, 20.0),
 ]
 
 RESOURCE_NODE_POSITIONS = [
-    (MAP_WIDTH / 2, MAP_HEIGHT / 2),
-    (MAP_WIDTH / 2 + 15, MAP_HEIGHT / 2 - 12),
-    (MAP_WIDTH / 2 - 20, MAP_HEIGHT / 2 + 16),
-    (MAP_WIDTH / 2 + 5, MAP_HEIGHT / 2 + 18),
+    (MAP_WIDTH * 0.5, MAP_HEIGHT * 0.5),
+    (MAP_WIDTH * 0.7, MAP_HEIGHT * 0.35),
+    (MAP_WIDTH * 0.3, MAP_HEIGHT * 0.7),
+    (MAP_WIDTH * 0.55, MAP_HEIGHT * 0.8),
 ]

--- a/web/styles.css
+++ b/web/styles.css
@@ -152,6 +152,12 @@ canvas#battlefield {
   border-color: var(--accent);
 }
 
+#production-buttons .queue-indicator {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
 .panel ul {
   padding-left: 1.2rem;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- enlarge the battlefield size and reposition resource nodes and spawns to give players more room
- space out starting base structures using orientation-aware offsets for easier selection
- expose buildable units in server snapshots and render production buttons dynamically with queue indicators on the client
- run the game simulation loop at fixed tick intervals for consistent combat timing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf2a12197c832ca2b46eaa2212fb2d