### PR TITLE
Introduce ECS skeleton for movement and combat

### DIFF
--- a/app/ecs/__init__.py
+++ b/app/ecs/__init__.py
@@ -1,0 +1,16 @@
+"""Entity-component system primitives used by the RTS simulation."""
+
+from . import components, systems, world
+from .components import CombatStats, Movement, Orders, Position, UnitLink
+from .world import World
+
+__all__ = [
+    "World",
+    "components",
+    "systems",
+    "CombatStats",
+    "Movement",
+    "Orders",
+    "Position",
+    "UnitLink",
+]

--- a/app/ecs/components.py
+++ b/app/ecs/components.py
@@ -1,0 +1,47 @@
+"""Component definitions used by the lightweight ECS implementation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from app.models import Vector2
+
+
+@dataclass
+class Position:
+    """Stores the world-space position for an entity."""
+
+    value: Vector2
+
+
+@dataclass
+class Movement:
+    """Encapsulates movement capabilities of an entity."""
+
+    speed: float
+
+
+@dataclass
+class Orders:
+    """Represents the current high-level order assigned to an entity."""
+
+    state: str = "idle"
+    target_position: Optional[Vector2] = None
+    target_entity_id: Optional[str] = None
+
+
+@dataclass
+class CombatStats:
+    """Basic combat information for units capable of attacking."""
+
+    damage: int
+    attack_range: float
+    cooldown: float
+    current_cooldown: float = 0.0
+
+
+@dataclass
+class UnitLink:
+    """Back-reference to the simulation's traditional unit identifier."""
+
+    unit_id: str

--- a/app/ecs/systems/__init__.py
+++ b/app/ecs/systems/__init__.py
@@ -1,0 +1,6 @@
+"""Pre-built systems that operate on ECS component data."""
+
+from .combat import CombatSystem
+from .movement import MovementSystem
+
+__all__ = ["CombatSystem", "MovementSystem"]

--- a/app/ecs/systems/combat.py
+++ b/app/ecs/systems/combat.py
@@ -1,0 +1,54 @@
+"""Combat related ECS system."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.ecs.components import CombatStats, Orders, UnitLink
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
+    from app.ecs.world import World
+    from app.game import RTSGame
+
+
+class CombatSystem:
+    """Handles combat decision making for units each tick."""
+
+    def __init__(self, game: "RTSGame") -> None:
+        self._game = game
+
+    def update(self, world: "World", dt: float) -> None:
+        for _, (combat, orders, link) in world.get_components(CombatStats, Orders, UnitLink):
+            unit = self._game.units.get(link.unit_id)
+            if not unit or not unit.is_alive():
+                continue
+            if unit.attack_damage <= 0:
+                continue
+
+            target = None
+            if orders.state == "attack" and orders.target_entity_id:
+                target = self._game.units.get(orders.target_entity_id) or self._game.buildings.get(
+                    orders.target_entity_id
+                )
+                if not target or not target.is_alive():
+                    unit.reset_orders()
+                    orders.state = unit.state
+                    orders.target_entity_id = None
+                    orders.target_position = None
+                    continue
+            else:
+                target = self._game._find_closest_enemy(unit)
+                if not target:
+                    continue
+                unit.state = "attack"
+                unit.target_entity_id = target.id
+                unit.target_position = target.position.copy()
+                orders.state = unit.state
+                orders.target_entity_id = unit.target_entity_id
+                orders.target_position = unit.target_position.copy()
+
+            self._game._attack_target(unit, target, dt)
+            combat.current_cooldown = unit.current_cooldown
+            if unit.state != orders.state or unit.target_entity_id != orders.target_entity_id:
+                orders.state = unit.state
+                orders.target_entity_id = unit.target_entity_id
+                orders.target_position = unit.target_position.copy() if unit.target_position else None

--- a/app/ecs/systems/movement.py
+++ b/app/ecs/systems/movement.py
@@ -1,0 +1,35 @@
+"""Movement related ECS system."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.ecs.components import Movement, Orders, Position, UnitLink
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
+    from app.ecs.world import World
+    from app.game import RTSGame
+
+
+class MovementSystem:
+    """Applies movement orders to units each simulation tick."""
+
+    def __init__(self, game: "RTSGame") -> None:
+        self._game = game
+
+    def update(self, world: "World", dt: float) -> None:
+        for _, (position, movement, orders, link) in world.get_components(
+            Position, Movement, Orders, UnitLink
+        ):
+            unit = self._game.units.get(link.unit_id)
+            if not unit or not unit.is_alive():
+                continue
+            if orders.state != "moving" or not orders.target_position:
+                continue
+
+            position.value.move_towards(orders.target_position, movement.speed * dt)
+            # ``position.value`` is the same Vector2 instance referenced by the unit.
+            if position.value.distance_to(orders.target_position) <= 0.5:
+                unit.reset_orders()
+                orders.state = unit.state
+                orders.target_position = None
+                orders.target_entity_id = None

--- a/app/ecs/world.py
+++ b/app/ecs/world.py
@@ -1,0 +1,59 @@
+"""Minimal entity-component storage used by the RTS simulation."""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Generator, Iterable, Tuple, Type, TypeVar
+
+
+ComponentType = TypeVar("ComponentType")
+
+
+class World:
+    """Stores entities and their components."""
+
+    def __init__(self) -> None:
+        self._next_entity_id: int = 1
+        self._components: Dict[Type[object], Dict[int, object]] = defaultdict(dict)
+
+    # ------------------------------------------------------------------
+    # Entity management
+    # ------------------------------------------------------------------
+    def create_entity(self) -> int:
+        entity_id = self._next_entity_id
+        self._next_entity_id += 1
+        return entity_id
+
+    def remove_entity(self, entity_id: int) -> None:
+        for component_map in self._components.values():
+            component_map.pop(entity_id, None)
+
+    # ------------------------------------------------------------------
+    # Component management
+    # ------------------------------------------------------------------
+    def add_component(self, entity_id: int, component: object) -> object:
+        self._components[type(component)][entity_id] = component
+        return component
+
+    def get_component(self, entity_id: int, component_type: Type[ComponentType]) -> ComponentType | None:
+        return self._components.get(component_type, {}).get(entity_id)  # type: ignore[return-value]
+
+    def get_components(self, *component_types: Type[object]) -> Generator[Tuple[int, Tuple[object, ...]], None, None]:
+        if not component_types:
+            return
+        smallest_type = min(component_types, key=lambda c: len(self._components.get(c, {})))
+        for entity_id in list(self._components.get(smallest_type, {}).keys()):
+            results = []
+            for component_type in component_types:
+                component = self._components.get(component_type, {}).get(entity_id)
+                if component is None:
+                    break
+                results.append(component)
+            else:
+                yield entity_id, tuple(results)
+
+    def remove_component(self, entity_id: int, component_type: Type[object]) -> None:
+        self._components.get(component_type, {}).pop(entity_id, None)
+
+    def entities_with(self, *component_types: Type[object]) -> Iterable[int]:
+        for entity_id, _ in self.get_components(*component_types):
+            yield entity_id


### PR DESCRIPTION
## Summary
- add a lightweight ECS package with component storage and movement/combat systems
- wire the server simulation to register units with the ECS and drive movement/combat through systems
- keep orders and cooldown components in sync with existing unit data structures

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf75524168832cb3f59e99685912bc